### PR TITLE
chore: Add React ^16.8 and ^17 to peer deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@
     <a href="https://github.com/th-km"><img src="https://avatars.githubusercontent.com/u/35410212?s=120&v=4" title="th-km" width="60" height="60" style="max-width:100%;"></a>
     <a href="https://github.com/rojadesign"><img src="https://avatars.githubusercontent.com/u/35687281?s=120&v=4" title="th-km"" width="60" height="60" style="max-width:100%;"></a>
     <a href="https://github.com/SaizFerri"><img src="https://avatars.githubusercontent.com/u/19834971?s=120&v=4" title="SaizFerri" width="60" height="60" style="max-width:100%;"></a>
+    <a href="https://github.com/horseeyephil"><img src="https://avatars.githubusercontent.com/u/32337092?s=120&v=4" title="horseeyephil" width="60" height="60" style="max-width:100%;"></a>
   </p>
 </div>
 

--- a/packages/embla-carousel-react/package.json
+++ b/packages/embla-carousel-react/package.json
@@ -60,6 +60,6 @@
     "embla-carousel": "7.0.4"
   },
   "peerDependencies": {
-    "react": "^18.1.0"
+    "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
   }
 }


### PR DESCRIPTION
## PR:
**Discussion:** https://github.com/davidjerleke/embla-carousel/discussions/391

Adds more versions of React so that projects that don't use 18 may install `embla-carousel-react` without errors of the missing peer dependency. This would usually require `--force` or `--legacy-peer-deps` to bypass.

## Validation:
- Forked repo and add commit: https://github.com/horseeyephil/embla-carousel/commits/master
- Used **gitpkg** (https://gitpkg.vercel.app/) to point to the `packages/embla-carousel-react` subdirectory.
Install as such: `npm install 'https://gitpkg.now.sh/horseeyephil/embla-carousel/packages/embla-carousel-react?master'`
- Install into a new project using React 17 as a dependency in `package.json`. The usual peer dependency error is not apparent.
- Validate: Change the dependency from React 17 to React 15 (outside of the new range). Observe errors (or warning if using Yarn):

<img width="1021" alt="Screen Shot 2022-11-05 at 8 37 46 PM" src="https://user-images.githubusercontent.com/32337092/200434301-7e1b9df9-0a11-426d-812b-b9f7a70ff489.png">

