### PR TITLE
fix: Examples url path corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
   <p align="center">
     <strong>
-      <code>&nbsp;<a href="https://www.embla-carousel.com/examples/static/">Examples</a>&nbsp;</code>
+      <code>&nbsp;<a href="https://www.embla-carousel.com/examples/">Examples</a>&nbsp;</code>
     </strong>
   </p>
 </div>


### PR DESCRIPTION
# Examples url path was wrong

- Hey david. I have corrected the link for `Examples` url path. Before, when it was clicked, a 404 page was appearing. Now it lands on the Examples: Overview page.

- > I was looking for a package to help me in one of my project and I was recommended Embla Carousel package so i checked it out on npm's official page and found this issue there.  