### PR TITLE
Fix old browsers not support add event to MediaQueryList

### DIFF
--- a/packages/embla-carousel/src/components/EventStore.ts
+++ b/packages/embla-carousel/src/components/EventStore.ts
@@ -22,8 +22,9 @@ export function EventStore(): EventStoreType {
     handler: EventHandlerType,
     options: EventOptionsType = { passive: true }
   ): EventStoreType {
-    node.addEventListener(type, handler, options)
-    listeners.push(() => node.removeEventListener(type, handler, options))
+    node.addEventListener?.(type, handler, options)
+    listeners.push(() => node.removeEventListener?.
+    (type, handler, options))
     return self
   }
 

--- a/packages/embla-carousel/src/components/EventStore.ts
+++ b/packages/embla-carousel/src/components/EventStore.ts
@@ -22,9 +22,13 @@ export function EventStore(): EventStoreType {
     handler: EventHandlerType,
     options: EventOptionsType = { passive: true }
   ): EventStoreType {
-    node.addEventListener?.(type, handler, options)
-    listeners.push(() => node.removeEventListener?.
-    (type, handler, options))
+    if ('addEventListener' in node) {
+      node.addEventListener(type, handler, options)
+      listeners.push(() => node.removeEventListener(type, handler, options))
+    } else if ('addListener' in node) {
+      (node as MediaQueryList).addListener(handler);
+      listeners.push(() => (node as MediaQueryList).removeListener(handler))
+    }
     return self
   }
 


### PR DESCRIPTION
check if addEventListener exist before using it