### PR TITLE
Fix leak in slidesInView event

### DIFF
--- a/packages/embla-carousel/src/components/EmblaCarousel.ts
+++ b/packages/embla-carousel/src/components/EmblaCarousel.ts
@@ -155,6 +155,7 @@ function EmblaCarousel(
     engine.slideLooper.clear()
     engine.resizeHandler.destroy()
     engine.slidesHandler.destroy()
+    engine.slidesInView.destroy()
     pluginsHandler.destroy()
     mediaHandlers.clear()
     documentVisibleHandler.clear()


### PR DESCRIPTION
Hello first time trying out this package and I love everything about it but there's just one thing that's causing me some issues regarding the `slidesInView` event. I've created this [Sandbox](https://codesandbox.io/s/embla-carousel-autoplay-react-forked-p7jyy5?file=/src/js/EmblaCarousel.tsx) to demonstrate the issue.

To reproduce:
1. Try not to resize the sandbox and see the counter "called" gets incremented by 1 perfectly fine
2. Resize the sandbox
3. Wait for the autoplay to slide automatically or slide it yourself
4. Counter "called" gets incremented by A LOT and this shouldn't happen

I've added `engine.slidesInView.destroy()` in the `deactivate` function to fix the issue in `embla-carousel` package.

We can also listen to the `reinit` event to destroy the event but I feel like this shouldn't be done on the end user but on the package's side.