### PR TITLE
Add focus interaction to autoplay

### DIFF
--- a/packages/embla-carousel-autoplay/src/components/Autoplay.ts
+++ b/packages/embla-carousel-autoplay/src/components/Autoplay.ts
@@ -69,8 +69,11 @@ function Autoplay(userOptions: AutoplayOptionsType = {}): AutoplayType {
     }
 
     if (options.stopOnFocusIn) {
-      eventStore.add(root, 'focusin', interaction);
-      if (!options.stopOnInteraction) eventStore.add(root, 'focusout', reset);
+      eventStore.add(root, 'focusin', clearTimer)
+
+      if (!options.stopOnInteraction) {
+        eventStore.add(root, 'focusout', startTimer)
+      }
     }
 
     eventStore.add(ownerDocument, 'visibilitychange', () => {

--- a/packages/embla-carousel-autoplay/src/components/Autoplay.ts
+++ b/packages/embla-carousel-autoplay/src/components/Autoplay.ts
@@ -68,6 +68,11 @@ function Autoplay(userOptions: AutoplayOptionsType = {}): AutoplayType {
       }
     }
 
+    if (options.stopOnFocusIn) {
+      eventStore.add(root, 'focusin', interaction);
+      if (!options.stopOnInteraction) eventStore.add(root, 'focusout', reset);
+    }
+
     eventStore.add(ownerDocument, 'visibilitychange', () => {
       if (ownerDocument.visibilityState === 'hidden') {
         wasPlaying = playing

--- a/packages/embla-carousel-autoplay/src/components/Options.ts
+++ b/packages/embla-carousel-autoplay/src/components/Options.ts
@@ -4,6 +4,7 @@ export type OptionsType = CreateOptionsType<{
   delay: number
   jump: boolean
   playOnInit: boolean
+  stopOnFocusIn: boolean
   stopOnInteraction: boolean
   stopOnMouseEnter: boolean
   stopOnLastSnap: boolean
@@ -16,6 +17,7 @@ export const defaultOptions: OptionsType = {
   delay: 4000,
   jump: false,
   playOnInit: true,
+  stopOnFocusIn: true,
   stopOnInteraction: true,
   stopOnMouseEnter: false,
   stopOnLastSnap: false,

--- a/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.mdx
@@ -117,16 +117,25 @@ If set to `false`, autoplay will not be disabled after drag interactions, and it
 Type: <BrandPrimaryText>`boolean`</BrandPrimaryText>  
 Default: <BrandSecondaryText>`false`</BrandSecondaryText>
 
-When enabled, autoplay will pause when a mouse pointer enters the Embla Carousel container. If [stopOnInteraction](/plugins/autoplay/#stoponinteraction) is also enabled, it will stop autoplay entirely instead of pausing it.
+When enabled, autoplay will pause when a mouse pointer enters the Embla Carousel container. If [stopOnInteraction](/plugins/autoplay/#stoponinteraction) is also `false`, autoplay will resume when the mouse leaves the carousel container.
 
 ---
+
+### stopOnFocusIn
+
+Type: <BrandPrimaryText>`boolean`</BrandPrimaryText>  
+Default: <BrandSecondaryText>`true`</BrandSecondaryText>
+
+---
+
+When enabled, autoplay will stop when a focusable element inside the carousel recieves focus. If [stopOnInteraction](/plugins/autoplay/#stoponinteraction) is `false`, autoplay will resume when the user leaves focus.
 
 ### stopOnLastSnap
 
 Type: <BrandPrimaryText>`boolean`</BrandPrimaryText>  
 Default: <BrandSecondaryText>`false`</BrandSecondaryText>
 
-If this parameter is enabled, autoplay will be stopped when it reaches last slide.
+If this parameter is enabled, autoplay will stop when it reaches last slide.
 
 ---
 


### PR DESCRIPTION
### Feature request is related to

- [x]  embla-carousel-autoplay (plugin)

### A clear and concise description of what the problem is.
The current implementation of stopOnInteraction does not stop if focus is received by a nested element.

### Describe the solution you'd like
This PR adds event handlers to the autoplay plugin to stop the autoplay if a bubbled up focus event is received by the root element.

