### PR TITLE
Make reading element dimensions work regardless of transforms

### DIFF
--- a/packages/embla-carousel-docs/src/components/Examples/createCarouselStyles.ts
+++ b/packages/embla-carousel-docs/src/components/Examples/createCarouselStyles.ts
@@ -505,15 +505,16 @@ const IOS_PICKER_STYLES = css`
     min-width: 100%;
     height: 100%;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    touch-action: pan-x;
   }
 
   .embla__ios-picker__viewport {
-    height: 100%;
+    height: 32px;
     width: 100%;
     position: relative;
-    display: flex;
     perspective: 1000px;
-    align-items: center;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
@@ -534,7 +535,7 @@ const IOS_PICKER_STYLES = css`
   }
 
   .embla__ios-picker__container {
-    height: 32px;
+    height: 100%;
     width: 100%;
     position: absolute;
     transform-style: preserve-3d;

--- a/packages/embla-carousel/src/__tests__/constructor.test.ts
+++ b/packages/embla-carousel/src/__tests__/constructor.test.ts
@@ -29,7 +29,7 @@ describe('➡️  EmblaCarousel', () => {
       expect(() =>
         EmblaCarousel(
           mockTestElements({
-            slideRects: [],
+            slideOffsets: [],
             endMargin: {
               property: 'marginRight',
               value: 0

--- a/packages/embla-carousel/src/__tests__/fixtures/align.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/align.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_LTR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -94,72 +64,42 @@ export const FIXTURE_ALIGN_LTR_1: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_LTR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 10,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 810,
-      bottom: 190,
-      left: 10,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 10
     },
     {
-      x: 830,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1230,
-      bottom: 190,
-      left: 830,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 830
     },
     {
-      x: 1250,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1450,
-      bottom: 190,
-      left: 1250,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1250
     },
     {
-      x: 1470,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1970,
-      bottom: 190,
-      left: 1470,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1470
     },
     {
-      x: 1990,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2290,
-      bottom: 190,
-      left: 1990,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1990
     }
   ],
   endMargin: {
@@ -178,72 +118,42 @@ export const FIXTURE_ALIGN_LTR_2: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_RTL_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 200,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 200,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 200
     },
     {
-      x: -200,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 200,
-      bottom: 190,
-      left: -200,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -200
     },
     {
-      x: -400,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -200,
-      bottom: 190,
-      left: -400,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -400
     },
     {
-      x: -900,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -400,
-      bottom: 190,
-      left: -900,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -900
     },
     {
-      x: -1200,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -900,
-      bottom: 190,
-      left: -1200,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -1200
     }
   ],
   endMargin: {
@@ -262,72 +172,42 @@ export const FIXTURE_ALIGN_RTL_1: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_RTL_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 190,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 990,
-      bottom: 190,
-      left: 190,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 190
     },
     {
-      x: -230,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 170,
-      bottom: 190,
-      left: -230,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -230
     },
     {
-      x: -450,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -250,
-      bottom: 190,
-      left: -450,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -450
     },
     {
-      x: -970,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -470,
-      bottom: 190,
-      left: -970,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -970
     },
     {
-      x: -1290,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -990,
-      bottom: 190,
-      left: -1290,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -1290
     }
   ],
   endMargin: {
@@ -345,72 +225,42 @@ export const FIXTURE_ALIGN_RTL_2: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_Y_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 800,
-      top: 0,
-      right: 1000,
-      bottom: 800,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 800,
-      width: 1000,
-      height: 400,
-      top: 800,
-      right: 1000,
-      bottom: 1200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 800,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1200,
-      width: 1000,
-      height: 200,
-      top: 1200,
-      right: 1000,
-      bottom: 1400,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1200,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1400,
-      width: 1000,
-      height: 500,
-      top: 1400,
-      right: 1000,
-      bottom: 1900,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1400,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1900,
-      width: 1000,
-      height: 300,
-      top: 1900,
-      right: 1000,
-      bottom: 2200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1900,
+      offsetLeft: 0
     }
   ],
   endMargin: {
@@ -428,72 +278,42 @@ export const FIXTURE_ALIGN_Y_1: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_ALIGN_Y_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 10,
-      width: 1000,
-      height: 800,
-      top: 10,
-      right: 1000,
-      bottom: 810,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 10,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 830,
-      width: 1000,
-      height: 400,
-      top: 830,
-      right: 1000,
-      bottom: 1230,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 830,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1250,
-      width: 1000,
-      height: 200,
-      top: 1250,
-      right: 1000,
-      bottom: 1450,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1250,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1470,
-      width: 1000,
-      height: 500,
-      top: 1470,
-      right: 1000,
-      bottom: 1970,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1470,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1990,
-      width: 1000,
-      height: 300,
-      top: 1990,
-      right: 1000,
-      bottom: 2290,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1990,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/axis.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/axis.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_AXIS_X_LTR: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -94,72 +64,42 @@ Fixture 2
 - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_AXIS_X_RTL: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 200,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 200,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 200
     },
     {
-      x: -200,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 200,
-      bottom: 190,
-      left: -200,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -200
     },
     {
-      x: -400,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -200,
-      bottom: 190,
-      left: -400,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -400
     },
     {
-      x: -900,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -400,
-      bottom: 190,
-      left: -900,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -900
     },
     {
-      x: -1200,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -900,
-      bottom: 190,
-      left: -1200,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -1200
     }
   ],
   endMargin: {
@@ -177,72 +117,42 @@ export const FIXTURE_AXIS_X_RTL: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_AXIS_Y: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 800,
-      top: 0,
-      right: 1000,
-      bottom: 800,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 800,
-      width: 1000,
-      height: 400,
-      top: 800,
-      right: 1000,
-      bottom: 1200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 800,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1200,
-      width: 1000,
-      height: 200,
-      top: 1200,
-      right: 1000,
-      bottom: 1400,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1200,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1400,
-      width: 1000,
-      height: 500,
-      top: 1400,
-      right: 1000,
-      bottom: 1900,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1400,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1900,
-      width: 1000,
-      height: 300,
-      top: 1900,
-      right: 1000,
-      bottom: 2200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1900,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/breakpoints.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/breakpoints.fixture.ts
@@ -10,72 +10,47 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_BREAKPOINTS: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1900
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/constructor.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/constructor.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_CONSTRUCTOR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -93,18 +63,13 @@ export const FIXTURE_CONSTRUCTOR_1: TestElementDimensionsType = {
   - No slides
 */
 export const FIXTURE_CONSTRUCTOR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [],
+  slideOffsets: [],
   endMargin: {
     property: 'marginRight',
     value: 0

--- a/packages/embla-carousel/src/__tests__/fixtures/containScroll.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/containScroll.fixture.ts
@@ -10,127 +10,72 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_LTR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 100,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 100,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 300,
-      bottom: 190,
-      left: 100,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 100
     },
     {
-      x: 300,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 450,
-      bottom: 190,
-      left: 300,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 300
     },
     {
-      x: 450,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 700,
-      bottom: 190,
-      left: 450,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 450
     },
     {
-      x: 700,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 830,
-      bottom: 190,
-      left: 700,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 700
     },
     {
-      x: 830,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 930,
-      bottom: 190,
-      left: 830,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 830
     },
     {
-      x: 930,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1130,
-      bottom: 190,
-      left: 930,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 930
     },
     {
-      x: 1130,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 1280,
-      bottom: 190,
-      left: 1130,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1130
     },
     {
-      x: 1280,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 1530,
-      bottom: 190,
-      left: 1280,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1280
     },
     {
-      x: 1530,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 1660,
-      bottom: 190,
-      left: 1530,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1530
     }
   ],
   endMargin: {
@@ -149,127 +94,72 @@ export const FIXTURE_CONTAIN_SCROLL_LTR_1: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_LTR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 10,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 110,
-      bottom: 190,
-      left: 10,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 10
     },
     {
-      x: 130,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 330,
-      bottom: 190,
-      left: 130,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 130
     },
     {
-      x: 350,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 500,
-      bottom: 190,
-      left: 350,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 350
     },
     {
-      x: 520,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 770,
-      bottom: 190,
-      left: 520,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 520
     },
     {
-      x: 790,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 920,
-      bottom: 190,
-      left: 790,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 790
     },
     {
-      x: 940,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 1040,
-      bottom: 190,
-      left: 940,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 940
     },
     {
-      x: 1060,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1260,
-      bottom: 190,
-      left: 1060,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1060
     },
     {
-      x: 1280,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 1430,
-      bottom: 190,
-      left: 1280,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1280
     },
     {
-      x: 1450,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 1700,
-      bottom: 190,
-      left: 1450,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1450
     },
     {
-      x: 1720,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 1850,
-      bottom: 190,
-      left: 1720,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1720
     }
   ],
   endMargin: {
@@ -288,127 +178,72 @@ export const FIXTURE_CONTAIN_SCROLL_LTR_2: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_RTL_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 900,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 900,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 900
     },
     {
-      x: 700,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 900,
-      bottom: 190,
-      left: 700,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 700
     },
     {
-      x: 550,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 700,
-      bottom: 190,
-      left: 550,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 550
     },
     {
-      x: 300,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 550,
-      bottom: 190,
-      left: 300,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 300
     },
     {
-      x: 170,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 300,
-      bottom: 190,
-      left: 170,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 170
     },
     {
-      x: 70,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 170,
-      bottom: 190,
-      left: 70,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 70
     },
     {
-      x: -130,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 70,
-      bottom: 190,
-      left: -130,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -130
     },
     {
-      x: -280,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: -130,
-      bottom: 190,
-      left: -280,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -280
     },
     {
-      x: -530,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: -280,
-      bottom: 190,
-      left: -530,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -530
     },
     {
-      x: -660,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: -530,
-      bottom: 190,
-      left: -660,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -660
     }
   ],
   endMargin: {
@@ -427,127 +262,72 @@ export const FIXTURE_CONTAIN_SCROLL_RTL_1: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_RTL_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 890,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 990,
-      bottom: 190,
-      left: 890,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 890
     },
     {
-      x: 670,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 870,
-      bottom: 190,
-      left: 670,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 670
     },
     {
-      x: 500,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 650,
-      bottom: 190,
-      left: 500,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 500
     },
     {
-      x: 230,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 480,
-      bottom: 190,
-      left: 230,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 230
     },
     {
-      x: 80,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 210,
-      bottom: 190,
-      left: 80,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 80
     },
     {
-      x: -40,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 60,
-      bottom: 190,
-      left: -40,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -40
     },
     {
-      x: -260,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -60,
-      bottom: 190,
-      left: -260,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -260
     },
     {
-      x: -430,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: -280,
-      bottom: 190,
-      left: -430,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -430
     },
     {
-      x: -700,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: -450,
-      bottom: 190,
-      left: -700,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -700
     },
     {
-      x: -850,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: -720,
-      bottom: 190,
-      left: -850,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -850
     }
   ],
   endMargin: {
@@ -565,127 +345,72 @@ export const FIXTURE_CONTAIN_SCROLL_RTL_2: TestElementDimensionsType = {
   - Slide heights: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_Y_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 100,
-      top: 0,
-      right: 1000,
-      bottom: 100,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 100,
-      width: 1000,
-      height: 200,
-      top: 100,
-      right: 1000,
-      bottom: 300,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 100,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 300,
-      width: 1000,
-      height: 150,
-      top: 300,
-      right: 1000,
-      bottom: 450,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 300,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 450,
-      width: 1000,
-      height: 250,
-      top: 450,
-      right: 1000,
-      bottom: 700,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 450,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 700,
-      width: 1000,
-      height: 130,
-      top: 700,
-      right: 1000,
-      bottom: 830,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 700,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 830,
-      width: 1000,
-      height: 100,
-      top: 830,
-      right: 1000,
-      bottom: 930,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 830,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 930,
-      width: 1000,
-      height: 200,
-      top: 930,
-      right: 1000,
-      bottom: 1130,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 930,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1130,
-      width: 1000,
-      height: 150,
-      top: 1130,
-      right: 1000,
-      bottom: 1280,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 1130,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1280,
-      width: 1000,
-      height: 250,
-      top: 1280,
-      right: 1000,
-      bottom: 1530,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1280,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1530,
-      width: 1000,
-      height: 130,
-      top: 1530,
-      right: 1000,
-      bottom: 1660,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 1530,
+      offsetLeft: 0
     }
   ],
   endMargin: {
@@ -703,127 +428,72 @@ export const FIXTURE_CONTAIN_SCROLL_Y_1: TestElementDimensionsType = {
   - Slide heights: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_CONTAIN_SCROLL_Y_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 10,
-      width: 1000,
-      height: 100,
-      top: 10,
-      right: 1000,
-      bottom: 110,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 10,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 130,
-      width: 1000,
-      height: 200,
-      top: 130,
-      right: 1000,
-      bottom: 330,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 130,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 350,
-      width: 1000,
-      height: 150,
-      top: 350,
-      right: 1000,
-      bottom: 500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 350,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 520,
-      width: 1000,
-      height: 250,
-      top: 520,
-      right: 1000,
-      bottom: 770,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 520,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 790,
-      width: 1000,
-      height: 130,
-      top: 790,
-      right: 1000,
-      bottom: 920,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 790,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 940,
-      width: 1000,
-      height: 100,
-      top: 940,
-      right: 1000,
-      bottom: 1040,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 940,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1060,
-      width: 1000,
-      height: 200,
-      top: 1060,
-      right: 1000,
-      bottom: 1260,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1060,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1280,
-      width: 1000,
-      height: 150,
-      top: 1280,
-      right: 1000,
-      bottom: 1430,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 1280,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1450,
-      width: 1000,
-      height: 250,
-      top: 1450,
-      right: 1000,
-      bottom: 1700,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1450,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1720,
-      width: 1000,
-      height: 130,
-      top: 1720,
-      right: 1000,
-      bottom: 1850,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 1720,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/events.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/events.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_EVENTS: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/loop.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/loop.fixture.ts
@@ -10,127 +10,72 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_LTR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 100,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 100,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 300,
-      bottom: 190,
-      left: 100,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 100
     },
     {
-      x: 300,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 450,
-      bottom: 190,
-      left: 300,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 300
     },
     {
-      x: 450,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 700,
-      bottom: 190,
-      left: 450,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 450
     },
     {
-      x: 700,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 830,
-      bottom: 190,
-      left: 700,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 700
     },
     {
-      x: 830,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 930,
-      bottom: 190,
-      left: 830,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 830
     },
     {
-      x: 930,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1130,
-      bottom: 190,
-      left: 930,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 930
     },
     {
-      x: 1130,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 1280,
-      bottom: 190,
-      left: 1130,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1130
     },
     {
-      x: 1280,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 1530,
-      bottom: 190,
-      left: 1280,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1280
     },
     {
-      x: 1530,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 1660,
-      bottom: 190,
-      left: 1530,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1530
     }
   ],
   endMargin: {
@@ -149,127 +94,72 @@ export const FIXTURE_LOOP_LTR_1: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_LTR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 10,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 110,
-      bottom: 190,
-      left: 10,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 10
     },
     {
-      x: 130,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 330,
-      bottom: 190,
-      left: 130,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 130
     },
     {
-      x: 350,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 500,
-      bottom: 190,
-      left: 350,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 350
     },
     {
-      x: 520,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 770,
-      bottom: 190,
-      left: 520,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 520
     },
     {
-      x: 790,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 920,
-      bottom: 190,
-      left: 790,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 790
     },
     {
-      x: 940,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 1040,
-      bottom: 190,
-      left: 940,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 940
     },
     {
-      x: 1060,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1260,
-      bottom: 190,
-      left: 1060,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1060
     },
     {
-      x: 1280,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 1430,
-      bottom: 190,
-      left: 1280,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1280
     },
     {
-      x: 1450,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 1700,
-      bottom: 190,
-      left: 1450,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1450
     },
     {
-      x: 1720,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 1850,
-      bottom: 190,
-      left: 1720,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1720
     }
   ],
   endMargin: {
@@ -288,127 +178,72 @@ export const FIXTURE_LOOP_LTR_2: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_RTL_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 900,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 900,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 900
     },
     {
-      x: 700,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 900,
-      bottom: 190,
-      left: 700,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 700
     },
     {
-      x: 550,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 700,
-      bottom: 190,
-      left: 550,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 550
     },
     {
-      x: 300,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 550,
-      bottom: 190,
-      left: 300,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 300
     },
     {
-      x: 170,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 300,
-      bottom: 190,
-      left: 170,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 170
     },
     {
-      x: 70,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 170,
-      bottom: 190,
-      left: 70,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 70
     },
     {
-      x: -130,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 70,
-      bottom: 190,
-      left: -130,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -130
     },
     {
-      x: -280,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: -130,
-      bottom: 190,
-      left: -280,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -280
     },
     {
-      x: -530,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: -280,
-      bottom: 190,
-      left: -530,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -530
     },
     {
-      x: -660,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: -530,
-      bottom: 190,
-      left: -660,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -660
     }
   ],
   endMargin: {
@@ -427,127 +262,72 @@ export const FIXTURE_LOOP_RTL_1: TestElementDimensionsType = {
   - Slide widths: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_RTL_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 890,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 990,
-      bottom: 190,
-      left: 890,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 890
     },
     {
-      x: 670,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 870,
-      bottom: 190,
-      left: 670,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 670
     },
     {
-      x: 500,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: 650,
-      bottom: 190,
-      left: 500,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 500
     },
     {
-      x: 230,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: 480,
-      bottom: 190,
-      left: 230,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 230
     },
     {
-      x: 80,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: 210,
-      bottom: 190,
-      left: 80,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 80
     },
     {
-      x: -40,
-      y: 0,
-      width: 100,
-      height: 190,
-      top: 0,
-      right: 60,
-      bottom: 190,
-      left: -40,
-      toJSON: () => undefined
+      offsetWidth: 100,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -40
     },
     {
-      x: -260,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -60,
-      bottom: 190,
-      left: -260,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -260
     },
     {
-      x: -430,
-      y: 0,
-      width: 150,
-      height: 190,
-      top: 0,
-      right: -280,
-      bottom: 190,
-      left: -430,
-      toJSON: () => undefined
+      offsetWidth: 150,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -430
     },
     {
-      x: -700,
-      y: 0,
-      width: 250,
-      height: 190,
-      top: 0,
-      right: -450,
-      bottom: 190,
-      left: -700,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -700
     },
     {
-      x: -850,
-      y: 0,
-      width: 130,
-      height: 190,
-      top: 0,
-      right: -720,
-      bottom: 190,
-      left: -850,
-      toJSON: () => undefined
+      offsetWidth: 130,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -850
     }
   ],
   endMargin: {
@@ -565,127 +345,72 @@ export const FIXTURE_LOOP_RTL_2: TestElementDimensionsType = {
   - Slide heights: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_Y_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 100,
-      top: 0,
-      right: 1000,
-      bottom: 100,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 100,
-      width: 1000,
-      height: 200,
-      top: 100,
-      right: 1000,
-      bottom: 300,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 100,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 300,
-      width: 1000,
-      height: 150,
-      top: 300,
-      right: 1000,
-      bottom: 450,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 300,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 450,
-      width: 1000,
-      height: 250,
-      top: 450,
-      right: 1000,
-      bottom: 700,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 450,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 700,
-      width: 1000,
-      height: 130,
-      top: 700,
-      right: 1000,
-      bottom: 830,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 700,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 830,
-      width: 1000,
-      height: 100,
-      top: 830,
-      right: 1000,
-      bottom: 930,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 830,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 930,
-      width: 1000,
-      height: 200,
-      top: 930,
-      right: 1000,
-      bottom: 1130,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 930,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1130,
-      width: 1000,
-      height: 150,
-      top: 1130,
-      right: 1000,
-      bottom: 1280,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 1130,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1280,
-      width: 1000,
-      height: 250,
-      top: 1280,
-      right: 1000,
-      bottom: 1530,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1280,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1530,
-      width: 1000,
-      height: 130,
-      top: 1530,
-      right: 1000,
-      bottom: 1660,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 1530,
+      offsetLeft: 0
     }
   ],
   endMargin: {
@@ -703,127 +428,72 @@ export const FIXTURE_LOOP_Y_1: TestElementDimensionsType = {
   - Slide heights: 100px, 200px, 150px, 250px, 130px, 100px, 200px, 150px, 250px, 130px
 */
 export const FIXTURE_LOOP_Y_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 10,
-      width: 1000,
-      height: 100,
-      top: 10,
-      right: 1000,
-      bottom: 110,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 10,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 130,
-      width: 1000,
-      height: 200,
-      top: 130,
-      right: 1000,
-      bottom: 330,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 130,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 350,
-      width: 1000,
-      height: 150,
-      top: 350,
-      right: 1000,
-      bottom: 500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 350,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 520,
-      width: 1000,
-      height: 250,
-      top: 520,
-      right: 1000,
-      bottom: 770,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 520,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 790,
-      width: 1000,
-      height: 130,
-      top: 790,
-      right: 1000,
-      bottom: 920,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 790,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 940,
-      width: 1000,
-      height: 100,
-      top: 940,
-      right: 1000,
-      bottom: 1040,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 100,
+      offsetTop: 940,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1060,
-      width: 1000,
-      height: 200,
-      top: 1060,
-      right: 1000,
-      bottom: 1260,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1060,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1280,
-      width: 1000,
-      height: 150,
-      top: 1280,
-      right: 1000,
-      bottom: 1430,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 150,
+      offsetTop: 1280,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1450,
-      width: 1000,
-      height: 250,
-      top: 1450,
-      right: 1000,
-      bottom: 1700,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1450,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1720,
-      width: 1000,
-      height: 130,
-      top: 1720,
-      right: 1000,
-      bottom: 1850,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 130,
+      offsetTop: 1720,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/plugins.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/plugins.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_PLUGINS: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/reInit.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/reInit.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_REINIT_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -94,72 +64,42 @@ export const FIXTURE_REINIT_1: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_REINIT_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 10,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 810,
-      bottom: 190,
-      left: 10,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 10
     },
     {
-      x: 830,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1230,
-      bottom: 190,
-      left: 830,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 830
     },
     {
-      x: 1250,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1450,
-      bottom: 190,
-      left: 1250,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1250
     },
     {
-      x: 1470,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1970,
-      bottom: 190,
-      left: 1470,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1470
     },
     {
-      x: 1990,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2290,
-      bottom: 190,
-      left: 1990,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1990
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/scrollProgress.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/scrollProgress.fixture.ts
@@ -10,72 +10,47 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_LTR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -94,72 +69,47 @@ export const FIXTURE_SCROLL_PROGRESS_LTR_1: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_LTR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 10,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 810,
-      bottom: 190,
-      left: 10,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 10
     },
     {
-      x: 830,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1230,
-      bottom: 190,
-      left: 830,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 830
     },
     {
-      x: 1250,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1450,
-      bottom: 190,
-      left: 1250,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1250
     },
     {
-      x: 1470,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1970,
-      bottom: 190,
-      left: 1470,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1470
     },
     {
-      x: 1990,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2290,
-      bottom: 190,
-      left: 1990,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 1990
     }
   ],
   endMargin: {
@@ -178,72 +128,47 @@ export const FIXTURE_SCROLL_PROGRESS_LTR_2: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_RTL_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 200,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 200,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 200
     },
     {
-      x: -200,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 200,
-      bottom: 190,
-      left: -200,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -200
     },
     {
-      x: -400,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -200,
-      bottom: 190,
-      left: -400,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -400
     },
     {
-      x: -900,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -400,
-      bottom: 190,
-      left: -900,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -900
     },
     {
-      x: -1200,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -900,
-      bottom: 190,
-      left: -1200,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -1200
     }
   ],
   endMargin: {
@@ -262,72 +187,47 @@ export const FIXTURE_SCROLL_PROGRESS_RTL_1: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_RTL_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 190,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 990,
-      bottom: 190,
-      left: 190,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: 190
     },
     {
-      x: -230,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 170,
-      bottom: 190,
-      left: -230,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -230
     },
     {
-      x: -450,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -250,
-      bottom: 190,
-      left: -450,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -450
     },
     {
-      x: -970,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -470,
-      bottom: 190,
-      left: -970,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -970
     },
     {
-      x: -1290,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -990,
-      bottom: 190,
-      left: -1290,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+
+      offsetLeft: -1290
     }
   ],
   endMargin: {
@@ -345,72 +245,47 @@ export const FIXTURE_SCROLL_PROGRESS_RTL_2: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_Y_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 800,
-      top: 0,
-      right: 1000,
-      bottom: 800,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 0,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 800,
-      width: 1000,
-      height: 400,
-      top: 800,
-      right: 1000,
-      bottom: 1200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 800,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1200,
-      width: 1000,
-      height: 200,
-      top: 1200,
-      right: 1000,
-      bottom: 1400,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1200,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1400,
-      width: 1000,
-      height: 500,
-      top: 1400,
-      right: 1000,
-      bottom: 1900,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1400,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1900,
-      width: 1000,
-      height: 300,
-      top: 1900,
-      right: 1000,
-      bottom: 2200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1900,
+
+      offsetLeft: 0
     }
   ],
   endMargin: {
@@ -428,72 +303,47 @@ export const FIXTURE_SCROLL_PROGRESS_Y_1: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SCROLL_PROGRESS_Y_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 10,
-      width: 1000,
-      height: 800,
-      top: 10,
-      right: 1000,
-      bottom: 810,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 10,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 830,
-      width: 1000,
-      height: 400,
-      top: 830,
-      right: 1000,
-      bottom: 1230,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 830,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1250,
-      width: 1000,
-      height: 200,
-      top: 1250,
-      right: 1000,
-      bottom: 1450,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1250,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1470,
-      width: 1000,
-      height: 500,
-      top: 1470,
-      right: 1000,
-      bottom: 1970,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1470,
+
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1990,
-      width: 1000,
-      height: 300,
-      top: 1990,
-      right: 1000,
-      bottom: 2290,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1990,
+
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/selectedAndPreviousSnap.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/selectedAndPreviousSnap.fixture.ts
@@ -10,72 +10,42 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SELECTED_PREVIOUS_SNAP_LTR: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 800,
-      bottom: 190,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 800,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 1200,
-      bottom: 190,
-      left: 800,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 800
     },
     {
-      x: 1200,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: 1400,
-      bottom: 190,
-      left: 1200,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1200
     },
     {
-      x: 1400,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: 1900,
-      bottom: 190,
-      left: 1400,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1400
     },
     {
-      x: 1900,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: 2200,
-      bottom: 190,
-      left: 1900,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 1900
     }
   ],
   endMargin: {
@@ -94,72 +64,42 @@ export const FIXTURE_SELECTED_PREVIOUS_SNAP_LTR: TestElementDimensionsType = {
   - Slide widths: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SELECTED_PREVIOUS_SNAP_RTL: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 200,
-      y: 0,
-      width: 800,
-      height: 190,
-      top: 0,
-      right: 1000,
-      bottom: 190,
-      left: 200,
-      toJSON: () => undefined
+      offsetWidth: 800,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: 200
     },
     {
-      x: -200,
-      y: 0,
-      width: 400,
-      height: 190,
-      top: 0,
-      right: 200,
-      bottom: 190,
-      left: -200,
-      toJSON: () => undefined
+      offsetWidth: 400,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -200
     },
     {
-      x: -400,
-      y: 0,
-      width: 200,
-      height: 190,
-      top: 0,
-      right: -200,
-      bottom: 190,
-      left: -400,
-      toJSON: () => undefined
+      offsetWidth: 200,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -400
     },
     {
-      x: -900,
-      y: 0,
-      width: 500,
-      height: 190,
-      top: 0,
-      right: -400,
-      bottom: 190,
-      left: -900,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -900
     },
     {
-      x: -1200,
-      y: 0,
-      width: 300,
-      height: 190,
-      top: 0,
-      right: -900,
-      bottom: 190,
-      left: -1200,
-      toJSON: () => undefined
+      offsetWidth: 300,
+      offsetHeight: 190,
+      offsetTop: 0,
+      offsetLeft: -1200
     }
   ],
   endMargin: {
@@ -177,72 +117,42 @@ export const FIXTURE_SELECTED_PREVIOUS_SNAP_RTL: TestElementDimensionsType = {
   - Slide heights: 800px, 400px, 200px, 500px, 300px
 */
 export const FIXTURE_SELECTED_PREVIOUS_SNAP_Y: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 800,
-      top: 0,
-      right: 1000,
-      bottom: 800,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 800,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 800,
-      width: 1000,
-      height: 400,
-      top: 800,
-      right: 1000,
-      bottom: 1200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 400,
+      offsetTop: 800,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1200,
-      width: 1000,
-      height: 200,
-      top: 1200,
-      right: 1000,
-      bottom: 1400,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 200,
+      offsetTop: 1200,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1400,
-      width: 1000,
-      height: 500,
-      top: 1400,
-      right: 1000,
-      bottom: 1900,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 1400,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1900,
-      width: 1000,
-      height: 300,
-      top: 1900,
-      right: 1000,
-      bottom: 2200,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 300,
+      offsetTop: 1900,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/fixtures/slidesToScroll.fixture.ts
+++ b/packages/embla-carousel/src/__tests__/fixtures/slidesToScroll.fixture.ts
@@ -10,127 +10,72 @@ import { TestElementDimensionsType } from '../mocks/testElements.mock'
   - Slide widths: 500px, 500px, 250px, 250px, 250px, 250px, 500px, 500px, 500px, 501px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_LTR_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 500,
-      bottom: 0,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 500,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 1000,
-      bottom: 0,
-      left: 500,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 500
     },
     {
-      x: 1000,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: 1250,
-      bottom: 0,
-      left: 1000,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1000
     },
     {
-      x: 1250,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: 1500,
-      bottom: 0,
-      left: 1250,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1250
     },
     {
-      x: 1500,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: 1750,
-      bottom: 0,
-      left: 1500,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1500
     },
     {
-      x: 1750,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: 2000,
-      bottom: 0,
-      left: 1750,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1750
     },
     {
-      x: 2000,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 2500,
-      bottom: 0,
-      left: 2000,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 2000
     },
     {
-      x: 2500,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 3000,
-      bottom: 0,
-      left: 2500,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 2500
     },
     {
-      x: 3000,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 3500,
-      bottom: 0,
-      left: 3000,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 3000
     },
     {
-      x: 3500,
-      y: 0,
-      width: 501,
-      height: 0,
-      top: 0,
-      right: 4001,
-      bottom: 0,
-      left: 3500,
-      toJSON: () => undefined
+      offsetWidth: 501,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 3500
     }
   ],
   endMargin: {
@@ -149,127 +94,72 @@ export const FIXTURE_SLIDES_TO_SCROLL_LTR_1: TestElementDimensionsType = {
   - Slide widths: 480px, 480px, 235px, 235px, 235px, 235px, 480px, 480px, 480px, 481px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_LTR_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 20,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 500,
-      bottom: 0,
-      left: 20,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 20
     },
     {
-      x: 520,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 1000,
-      bottom: 0,
-      left: 520,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 520
     },
     {
-      x: 1020,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: 1255,
-      bottom: 0,
-      left: 1020,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1020
     },
     {
-      x: 1275,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: 1510,
-      bottom: 0,
-      left: 1275,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1275
     },
     {
-      x: 1530,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: 1765,
-      bottom: 0,
-      left: 1530,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1530
     },
     {
-      x: 1785,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: 2020,
-      bottom: 0,
-      left: 1785,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 1785
     },
     {
-      x: 2040,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 2520,
-      bottom: 0,
-      left: 2040,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 2040
     },
     {
-      x: 2540,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 3020,
-      bottom: 0,
-      left: 2540,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 2540
     },
     {
-      x: 3040,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 3520,
-      bottom: 0,
-      left: 3040,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 3040
     },
     {
-      x: 3540,
-      y: 0,
-      width: 481,
-      height: 0,
-      top: 0,
-      right: 4021,
-      bottom: 0,
-      left: 3540,
-      toJSON: () => undefined
+      offsetWidth: 481,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 3540
     }
   ],
   endMargin: {
@@ -288,127 +178,72 @@ export const FIXTURE_SLIDES_TO_SCROLL_LTR_2: TestElementDimensionsType = {
   - Slide widths: 500px, 500px, 250px, 250px, 250px, 250px, 500px, 500px, 500px, 501px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_RTL_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 500,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 1000,
-      bottom: 0,
-      left: 500,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 500
     },
     {
-      x: 0,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: 500,
-      bottom: 0,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: -250,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: -250,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -250
     },
     {
-      x: -500,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: -250,
-      bottom: 0,
-      left: -500,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -500
     },
     {
-      x: -750,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: -500,
-      bottom: 0,
-      left: -750,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -750
     },
     {
-      x: -1000,
-      y: 0,
-      width: 250,
-      height: 0,
-      top: 0,
-      right: -750,
-      bottom: 0,
-      left: -1000,
-      toJSON: () => undefined
+      offsetWidth: 250,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -1000
     },
     {
-      x: -1500,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: -1000,
-      bottom: 0,
-      left: -1500,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -1500
     },
     {
-      x: -2000,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: -1500,
-      bottom: 0,
-      left: -2000,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -2000
     },
     {
-      x: -2500,
-      y: 0,
-      width: 500,
-      height: 0,
-      top: 0,
-      right: -2000,
-      bottom: 0,
-      left: -2500,
-      toJSON: () => undefined
+      offsetWidth: 500,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -2500
     },
     {
-      x: -3001,
-      y: 0,
-      width: 501,
-      height: 0,
-      top: 0,
-      right: -2500,
-      bottom: 0,
-      left: -3001,
-      toJSON: () => undefined
+      offsetWidth: 501,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -3001
     }
   ],
   endMargin: {
@@ -427,127 +262,72 @@ export const FIXTURE_SLIDES_TO_SCROLL_RTL_1: TestElementDimensionsType = {
   - Slide widths: 480px, 480px, 235px, 235px, 235px, 235px, 480px, 480px, 480px, 481px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_RTL_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 190,
-    top: 0,
-    right: 1000,
-    bottom: 190,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 190,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 500,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 980,
-      bottom: 0,
-      left: 500,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 500
     },
     {
-      x: 0,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: 480,
-      bottom: 0,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: -255,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: -20,
-      bottom: 0,
-      left: -255,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -255
     },
     {
-      x: -510,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: -275,
-      bottom: 0,
-      left: -510,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -510
     },
     {
-      x: -765,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: -530,
-      bottom: 0,
-      left: -765,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -765
     },
     {
-      x: -1020,
-      y: 0,
-      width: 235,
-      height: 0,
-      top: 0,
-      right: -785,
-      bottom: 0,
-      left: -1020,
-      toJSON: () => undefined
+      offsetWidth: 235,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -1020
     },
     {
-      x: -1520,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: -1040,
-      bottom: 0,
-      left: -1520,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -1520
     },
     {
-      x: -2020,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: -1540,
-      bottom: 0,
-      left: -2020,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -2020
     },
     {
-      x: -2520,
-      y: 0,
-      width: 480,
-      height: 0,
-      top: 0,
-      right: -2040,
-      bottom: 0,
-      left: -2520,
-      toJSON: () => undefined
+      offsetWidth: 480,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -2520
     },
     {
-      x: -3021,
-      y: 0,
-      width: 481,
-      height: 0,
-      top: 0,
-      right: -2540,
-      bottom: 0,
-      left: -3021,
-      toJSON: () => undefined
+      offsetWidth: 481,
+      offsetHeight: 0,
+      offsetTop: 0,
+      offsetLeft: -3021
     }
   ],
   endMargin: {
@@ -565,127 +345,72 @@ export const FIXTURE_SLIDES_TO_SCROLL_RTL_2: TestElementDimensionsType = {
   - Slide heights: 500px, 500px, 250px, 250px, 250px, 250px, 500px, 500px, 500px, 501px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_Y_1: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 0,
-      width: 1000,
-      height: 500,
-      top: 0,
-      right: 1000,
-      bottom: 500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 0,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 500,
-      width: 1000,
-      height: 500,
-      top: 500,
-      right: 1000,
-      bottom: 1000,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 500,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1000,
-      width: 1000,
-      height: 250,
-      top: 1000,
-      right: 1000,
-      bottom: 1250,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1000,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1250,
-      width: 1000,
-      height: 250,
-      top: 1250,
-      right: 1000,
-      bottom: 1500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1250,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1500,
-      width: 1000,
-      height: 250,
-      top: 1500,
-      right: 1000,
-      bottom: 1750,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1500,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1750,
-      width: 1000,
-      height: 250,
-      top: 1750,
-      right: 1000,
-      bottom: 2000,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 250,
+      offsetTop: 1750,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 2000,
-      width: 1000,
-      height: 500,
-      top: 2000,
-      right: 1000,
-      bottom: 2500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 2000,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 2500,
-      width: 1000,
-      height: 500,
-      top: 2500,
-      right: 1000,
-      bottom: 3000,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 2500,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 3000,
-      width: 1000,
-      height: 500,
-      top: 3000,
-      right: 1000,
-      bottom: 3500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 500,
+      offsetTop: 3000,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 3500,
-      width: 1000,
-      height: 501,
-      top: 3500,
-      right: 1000,
-      bottom: 4001,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 501,
+      offsetTop: 3500,
+      offsetLeft: 0
     }
   ],
   endMargin: {
@@ -703,127 +428,72 @@ export const FIXTURE_SLIDES_TO_SCROLL_Y_1: TestElementDimensionsType = {
   - Slide heights: 480px, 480px, 235px, 235px, 235px, 235px, 480px, 480px, 480px, 481px
 */
 export const FIXTURE_SLIDES_TO_SCROLL_Y_2: TestElementDimensionsType = {
-  containerRect: {
-    x: 0,
-    y: 0,
-    width: 1000,
-    height: 1000,
-    top: 0,
-    right: 1000,
-    bottom: 1000,
-    left: 0,
-    toJSON: () => undefined
+  containerOffset: {
+    offsetWidth: 1000,
+    offsetHeight: 1000,
+    offsetTop: 0,
+    offsetLeft: 0
   },
-  slideRects: [
+  slideOffsets: [
     {
-      x: 0,
-      y: 20,
-      width: 1000,
-      height: 480,
-      top: 20,
-      right: 1000,
-      bottom: 500,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 480,
+      offsetTop: 20,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 520,
-      width: 1000,
-      height: 480,
-      top: 520,
-      right: 1000,
-      bottom: 1000,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 480,
+      offsetTop: 520,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1020,
-      width: 1000,
-      height: 235,
-      top: 1020,
-      right: 1000,
-      bottom: 1255,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 235,
+      offsetTop: 1020,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1275,
-      width: 1000,
-      height: 235,
-      top: 1275,
-      right: 1000,
-      bottom: 1510,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 235,
+      offsetTop: 1275,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1530,
-      width: 1000,
-      height: 235,
-      top: 1530,
-      right: 1000,
-      bottom: 1765,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 235,
+      offsetTop: 1530,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 1785,
-      width: 1000,
-      height: 235,
-      top: 1785,
-      right: 1000,
-      bottom: 2020,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 235,
+      offsetTop: 1785,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 2040,
-      width: 1000,
-      height: 480,
-      top: 2040,
-      right: 1000,
-      bottom: 2520,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 480,
+      offsetTop: 2040,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 2540,
-      width: 1000,
-      height: 480,
-      top: 2540,
-      right: 1000,
-      bottom: 3020,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 480,
+      offsetTop: 2540,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 3040,
-      width: 1000,
-      height: 480,
-      top: 3040,
-      right: 1000,
-      bottom: 3520,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 480,
+      offsetTop: 3040,
+      offsetLeft: 0
     },
     {
-      x: 0,
-      y: 3540,
-      width: 1000,
-      height: 481,
-      top: 3540,
-      right: 1000,
-      bottom: 4021,
-      left: 0,
-      toJSON: () => undefined
+      offsetWidth: 1000,
+      offsetHeight: 481,
+      offsetTop: 3540,
+      offsetLeft: 0
     }
   ],
   endMargin: {

--- a/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
+++ b/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
@@ -7,6 +7,13 @@ export type TestElementDimensionsType = {
   }
 }
 
+function mockNodeRects(node: HTMLElement, rect: DOMRect): void {
+  Object.defineProperty(node, 'offsetTop', { value: rect.top })
+  Object.defineProperty(node, 'offsetLeft', { value: rect.left })
+  Object.defineProperty(node, 'offsetWidth', { value: rect.width })
+  Object.defineProperty(node, 'offsetHeight', { value: rect.height })
+}
+
 export function mockTestElementDimensions(
   dimensions: TestElementDimensionsType,
   rootNode: HTMLElement
@@ -20,18 +27,9 @@ export function mockTestElementDimensions(
   containerNode.innerHTML = ''
   slideNodes.forEach((slideNode) => containerNode.appendChild(slideNode))
 
-  const mockNodeOffset = (node: any, rect: DOMRect) => {
-    Object.defineProperty(node, 'offsetTop', { value: rect.top })
-    Object.defineProperty(node, 'offsetLeft', { value: rect.left })
-    Object.defineProperty(node, 'offsetWidth', { value: rect.width })
-    Object.defineProperty(node, 'offsetHeight', { value: rect.height })
-  }
-
-  mockNodeOffset(rootNode, containerRect)
-  mockNodeOffset(containerNode, containerRect)
-  slideNodes.forEach((s, i) => {
-    mockNodeOffset(s, slideRects[i])
-  })
+  mockNodeRects(rootNode, containerRect)
+  mockNodeRects(containerNode, containerRect)
+  slideNodes.forEach((s, i) => mockNodeRects(s, slideRects[i]))
 
   if (!slideNodes.length) return
 

--- a/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
+++ b/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
@@ -21,7 +21,6 @@ export function mockTestElementDimensions(
   slideNodes.forEach((slideNode) => containerNode.appendChild(slideNode))
 
   const fixNodeRect = (node: any, rect: DOMRect) => {
-    node.getBoundingClientRect = () => rect
     Object.defineProperty(node, 'offsetTop', { value: rect.top })
     Object.defineProperty(node, 'offsetLeft', { value: rect.left })
     Object.defineProperty(node, 'offsetWidth', { value: rect.width })

--- a/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
+++ b/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
@@ -20,9 +20,19 @@ export function mockTestElementDimensions(
   containerNode.innerHTML = ''
   slideNodes.forEach((slideNode) => containerNode.appendChild(slideNode))
 
-  rootNode.getBoundingClientRect = () => containerRect
-  containerNode.getBoundingClientRect = () => containerRect
-  slideNodes.forEach((s, i) => (s.getBoundingClientRect = () => slideRects[i]))
+  const fixNodeRect = (node: any, rect: DOMRect) => {
+    node.getBoundingClientRect = () => rect
+    Object.defineProperty(node, 'offsetTop', { value: rect.top })
+    Object.defineProperty(node, 'offsetLeft', { value: rect.left })
+    Object.defineProperty(node, 'offsetWidth', { value: rect.width })
+    Object.defineProperty(node, 'offsetHeight', { value: rect.height })
+  }
+
+  fixNodeRect(rootNode, containerRect)
+  fixNodeRect(containerNode, containerRect)
+  slideNodes.forEach((s, i) => {
+    fixNodeRect(s, slideRects[i])
+  })
 
   if (!slideNodes.length) return
 

--- a/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
+++ b/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
@@ -20,17 +20,17 @@ export function mockTestElementDimensions(
   containerNode.innerHTML = ''
   slideNodes.forEach((slideNode) => containerNode.appendChild(slideNode))
 
-  const fixNodeRect = (node: any, rect: DOMRect) => {
+  const mockNodeOffset = (node: any, rect: DOMRect) => {
     Object.defineProperty(node, 'offsetTop', { value: rect.top })
     Object.defineProperty(node, 'offsetLeft', { value: rect.left })
     Object.defineProperty(node, 'offsetWidth', { value: rect.width })
     Object.defineProperty(node, 'offsetHeight', { value: rect.height })
   }
 
-  fixNodeRect(rootNode, containerRect)
-  fixNodeRect(containerNode, containerRect)
+  mockNodeOffset(rootNode, containerRect)
+  mockNodeOffset(containerNode, containerRect)
   slideNodes.forEach((s, i) => {
-    fixNodeRect(s, slideRects[i])
+    mockNodeOffset(s, slideRects[i])
   })
 
   if (!slideNodes.length) return

--- a/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
+++ b/packages/embla-carousel/src/__tests__/mocks/testElements.mock.ts
@@ -1,35 +1,46 @@
+type TestElementOffsetType = {
+  offsetLeft: number
+  offsetTop: number
+  offsetWidth: number
+  offsetHeight: number
+}
+
 export type TestElementDimensionsType = {
-  containerRect?: DOMRect
-  slideRects: DOMRect[]
+  containerOffset?: TestElementOffsetType
+  slideOffsets: TestElementOffsetType[]
   endMargin: {
     property: 'marginLeft' | 'marginRight' | 'marginTop' | 'marginBottom'
     value: number
   }
 }
 
-function mockNodeRects(node: HTMLElement, rect: DOMRect): void {
-  Object.defineProperty(node, 'offsetTop', { value: rect.top })
-  Object.defineProperty(node, 'offsetLeft', { value: rect.left })
-  Object.defineProperty(node, 'offsetWidth', { value: rect.width })
-  Object.defineProperty(node, 'offsetHeight', { value: rect.height })
+function mockNodeOffsets(
+  node: HTMLElement,
+  offsets: TestElementOffsetType
+): void {
+  const { offsetTop, offsetLeft, offsetWidth, offsetHeight } = offsets
+  Object.defineProperty(node, 'offsetTop', { value: offsetTop })
+  Object.defineProperty(node, 'offsetLeft', { value: offsetLeft })
+  Object.defineProperty(node, 'offsetWidth', { value: offsetWidth })
+  Object.defineProperty(node, 'offsetHeight', { value: offsetHeight })
 }
 
 export function mockTestElementDimensions(
   dimensions: TestElementDimensionsType,
   rootNode: HTMLElement
 ): void {
-  const { containerRect, slideRects, endMargin } = dimensions
+  const { containerOffset, slideOffsets, endMargin } = dimensions
   const containerNode = <HTMLElement>rootNode.children[0]
-  const slideNodes = slideRects.map(() => document.createElement('div'))
+  const slideNodes = slideOffsets.map(() => document.createElement('div'))
 
-  if (!containerRect) return
+  if (!containerOffset) return
 
   containerNode.innerHTML = ''
   slideNodes.forEach((slideNode) => containerNode.appendChild(slideNode))
 
-  mockNodeRects(rootNode, containerRect)
-  mockNodeRects(containerNode, containerRect)
-  slideNodes.forEach((s, i) => mockNodeRects(s, slideRects[i]))
+  mockNodeOffsets(rootNode, containerOffset)
+  mockNodeOffsets(containerNode, containerOffset)
+  slideNodes.forEach((s, i) => mockNodeOffsets(s, slideOffsets[i]))
 
   if (!slideNodes.length) return
 
@@ -40,11 +51,11 @@ export function mockTestElementDimensions(
 export function mockTestElements(
   dimensions: TestElementDimensionsType
 ): HTMLElement {
-  const { containerRect } = dimensions
+  const { containerOffset } = dimensions
   const rootNode = document.createElement('div')
   const containerNode = document.createElement('div')
 
-  if (containerRect) {
+  if (containerOffset) {
     rootNode.appendChild(containerNode)
     mockTestElementDimensions(dimensions, rootNode)
   }

--- a/packages/embla-carousel/src/__tests__/reInit.test.ts
+++ b/packages/embla-carousel/src/__tests__/reInit.test.ts
@@ -32,10 +32,10 @@ describe('➡️  ReInit', () => {
     expect(engine.scrollSnaps).toEqual(expectedScrollSnaps)
     expect(engine.location.get()).toBe(expectedScrollSnaps[FIRST_SNAP_INDEX])
 
-    const slideRects = FIXTURE_REINIT_1.slideRects
+    const slideOffsets = FIXTURE_REINIT_1.slideOffsets
     const fixtureAllSlidesButFirst = {
       ...FIXTURE_REINIT_1,
-      slideRects: slideRects.slice(0, slideRects.length - 1)
+      slideOffsets: slideOffsets.slice(0, slideOffsets.length - 1)
     }
     mockTestElementDimensions(fixtureAllSlidesButFirst, emblaApi.rootNode())
     emblaApi.reInit()

--- a/packages/embla-carousel/src/__tests__/selectedAndPreviousSnap.test.ts
+++ b/packages/embla-carousel/src/__tests__/selectedAndPreviousSnap.test.ts
@@ -11,7 +11,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Horizontal LTR', () 
     const emblaApi = EmblaCarousel(
       mockTestElements(FIXTURE_SELECTED_PREVIOUS_SNAP_LTR)
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_LTR.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_LTR.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {
@@ -90,7 +90,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Horizontal LTR', () 
       mockTestElements(FIXTURE_SELECTED_PREVIOUS_SNAP_LTR),
       { loop: true }
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_LTR.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_LTR.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {
@@ -171,7 +171,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Horizontal RTL', () 
       mockTestElements(FIXTURE_SELECTED_PREVIOUS_SNAP_RTL),
       { direction: 'rtl' }
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_RTL.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_RTL.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {
@@ -253,7 +253,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Horizontal RTL', () 
         loop: true
       }
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_RTL.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_RTL.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {
@@ -336,7 +336,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Vertical', () => {
         axis: 'y'
       }
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_Y.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_Y.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {
@@ -418,7 +418,7 @@ describe('➡️  SelectedScrollSnap & PreviousScrollSnap - Vertical', () => {
         loop: true
       }
     )
-    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_Y.slideRects.length - 1
+    const lastIndex = FIXTURE_SELECTED_PREVIOUS_SNAP_Y.slideOffsets.length - 1
     const firstIndex = 0
 
     beforeEach(() => {

--- a/packages/embla-carousel/src/components/Axis.ts
+++ b/packages/embla-carousel/src/components/Axis.ts
@@ -1,4 +1,5 @@
 import { DirectionOptionType } from './Direction'
+import { NodeRectType } from './NodeRects'
 
 export type AxisOptionType = 'x' | 'y'
 type AxisEdgeType = 'top' | 'right' | 'bottom' | 'left'
@@ -8,7 +9,7 @@ export type AxisType = {
   cross: AxisOptionType
   startEdge: AxisEdgeType
   endEdge: AxisEdgeType
-  measureSize: (rect: DOMRect) => number
+  measureSize: (nodeRect: NodeRectType) => number
 }
 
 export function Axis(
@@ -20,8 +21,8 @@ export function Axis(
   const startEdge = getStartEdge()
   const endEdge = getEndEdge()
 
-  function measureSize(rect: DOMRect): number {
-    const { width, height } = rect
+  function measureSize(nodeRect: NodeRectType): number {
+    const { width, height } = nodeRect
     return scroll === 'x' ? width : height
   }
 

--- a/packages/embla-carousel/src/components/Engine.ts
+++ b/packages/embla-carousel/src/components/Engine.ts
@@ -7,6 +7,7 @@ import { DragTracker } from './DragTracker'
 import { EventHandlerType } from './EventHandler'
 import { EventStore, EventStoreType } from './EventStore'
 import { LimitType } from './Limit'
+import { NodeRectType, NodeRects } from './NodeRects'
 import { OptionsType } from './Options'
 import { PercentOfView, PercentOfViewType } from './PercentOfView'
 import { ResizeHandler, ResizeHandlerType } from './ResizeHandler'
@@ -27,13 +28,7 @@ import { SlidesInView, SlidesInViewType } from './SlidesInView'
 import { SlideSizes } from './SlideSizes'
 import { SlidesToScroll, SlidesToScrollType } from './SlidesToScroll'
 import { Translate, TranslateType } from './Translate'
-import {
-  arrayKeys,
-  arrayLast,
-  arrayLastIndex,
-  getNodeRect,
-  WindowType
-} from './utils'
+import { arrayKeys, arrayLast, arrayLastIndex, WindowType } from './utils'
 import { Vector1D, Vector1DType } from './Vector1d'
 import {
   AnimationType,
@@ -76,8 +71,8 @@ export type EngineType = {
   slideIndexes: number[]
   slideFocus: SlideFocusType
   slideRegistry: SlideRegistryType['slideRegistry']
-  containerRect: DOMRect
-  slideRects: DOMRect[]
+  containerRect: NodeRectType
+  slideRects: NodeRectType[]
 }
 
 export function Engine(
@@ -110,8 +105,9 @@ export function Engine(
   } = options
 
   // Measurements
-  const containerRect = getNodeRect(container)
-  const slideRects = slides.map((slide) => getNodeRect(slide))
+  const nodeRects = NodeRects()
+  const containerRect = nodeRects.measure(container)
+  const slideRects = slides.map(nodeRects.measure)
   const direction = Direction(contentDirection)
   const axis = Axis(scrollAxis, contentDirection)
   const viewSize = axis.measureSize(containerRect)
@@ -312,7 +308,8 @@ export function Engine(
       ownerWindow,
       slides,
       axis,
-      watchResize
+      watchResize,
+      nodeRects
     ),
     scrollBody,
     scrollBounds: ScrollBounds(

--- a/packages/embla-carousel/src/components/Engine.ts
+++ b/packages/embla-carousel/src/components/Engine.ts
@@ -27,7 +27,13 @@ import { SlidesInView, SlidesInViewType } from './SlidesInView'
 import { SlideSizes } from './SlideSizes'
 import { SlidesToScroll, SlidesToScrollType } from './SlidesToScroll'
 import { Translate, TranslateType } from './Translate'
-import { arrayKeys, arrayLast, arrayLastIndex, WindowType } from './utils'
+import {
+  arrayKeys,
+  arrayLast,
+  arrayLastIndex,
+  getNodeRect,
+  WindowType
+} from './utils'
 import { Vector1D, Vector1DType } from './Vector1d'
 import {
   AnimationType,
@@ -104,8 +110,8 @@ export function Engine(
   } = options
 
   // Measurements
-  const containerRect = container.getBoundingClientRect()
-  const slideRects = slides.map((slide) => slide.getBoundingClientRect())
+  const containerRect = getNodeRect(container)
+  const slideRects = slides.map((slide) => getNodeRect(slide))
   const direction = Direction(contentDirection)
   const axis = Axis(scrollAxis, contentDirection)
   const viewSize = axis.measureSize(containerRect)

--- a/packages/embla-carousel/src/components/NodeRects.ts
+++ b/packages/embla-carousel/src/components/NodeRects.ts
@@ -1,0 +1,33 @@
+export type NodeRectType = {
+  top: number
+  right: number
+  bottom: number
+  left: number
+  width: number
+  height: number
+}
+
+export type NodeRectsType = {
+  measure: (node: HTMLElement) => NodeRectType
+}
+
+export function NodeRects(): NodeRectsType {
+  function measure(node: HTMLElement): NodeRectType {
+    const { offsetTop, offsetLeft, offsetWidth, offsetHeight } = node
+    const offset: NodeRectType = {
+      top: offsetTop,
+      right: offsetLeft + offsetWidth,
+      bottom: offsetTop + offsetHeight,
+      left: offsetLeft,
+      width: offsetWidth,
+      height: offsetHeight
+    }
+
+    return offset
+  }
+
+  const self: NodeRectsType = {
+    measure
+  }
+  return self
+}

--- a/packages/embla-carousel/src/components/ResizeHandler.ts
+++ b/packages/embla-carousel/src/components/ResizeHandler.ts
@@ -1,7 +1,7 @@
 import { AxisType } from './Axis'
 import { EmblaCarouselType } from './EmblaCarousel'
 import { EventHandlerType } from './EventHandler'
-import { isBoolean, mathAbs, WindowType } from './utils'
+import { getNodeRect, isBoolean, mathAbs, WindowType } from './utils'
 
 type ResizeHandlerCallbackType = (
   emblaApi: EmblaCarouselType,
@@ -28,8 +28,8 @@ export function ResizeHandler(
   let slideSizes: number[] = []
   let destroyed = false
 
-  function readSize(node: Element | HTMLElement): number {
-    return axis.measureSize(node.getBoundingClientRect())
+  function readSize(node: HTMLElement): number {
+    return axis.measureSize(getNodeRect(node))
   }
 
   function init(emblaApi: EmblaCarouselType): void {

--- a/packages/embla-carousel/src/components/ResizeHandler.ts
+++ b/packages/embla-carousel/src/components/ResizeHandler.ts
@@ -1,7 +1,8 @@
 import { AxisType } from './Axis'
 import { EmblaCarouselType } from './EmblaCarousel'
 import { EventHandlerType } from './EventHandler'
-import { getNodeRect, isBoolean, mathAbs, WindowType } from './utils'
+import { NodeRectsType } from './NodeRects'
+import { isBoolean, mathAbs, WindowType } from './utils'
 
 type ResizeHandlerCallbackType = (
   emblaApi: EmblaCarouselType,
@@ -21,7 +22,8 @@ export function ResizeHandler(
   ownerWindow: WindowType,
   slides: HTMLElement[],
   axis: AxisType,
-  watchResize: ResizeHandlerOptionType
+  watchResize: ResizeHandlerOptionType,
+  nodeRects: NodeRectsType
 ): ResizeHandlerType {
   let resizeObserver: ResizeObserver
   let containerSize: number
@@ -29,7 +31,7 @@ export function ResizeHandler(
   let destroyed = false
 
   function readSize(node: HTMLElement): number {
-    return axis.measureSize(getNodeRect(node))
+    return axis.measureSize(nodeRects.measure(node))
   }
 
   function init(emblaApi: EmblaCarouselType): void {
@@ -46,7 +48,7 @@ export function ResizeHandler(
         const newSize = readSize(isContainer ? container : slides[slideIndex])
         const diffSize = mathAbs(newSize - lastSize)
 
-        if (diffSize >= 0.2) {
+        if (diffSize >= 0.5) {
           ownerWindow.requestAnimationFrame(() => {
             emblaApi.reInit()
             eventHandler.emit('resize')

--- a/packages/embla-carousel/src/components/ScrollSnaps.ts
+++ b/packages/embla-carousel/src/components/ScrollSnaps.ts
@@ -1,5 +1,6 @@
 import { AlignmentType } from './Alignment'
 import { AxisType } from './Axis'
+import { NodeRectType } from './NodeRects'
 import { SlidesToScrollType } from './SlidesToScroll'
 import { arrayLast, mathAbs } from './utils'
 
@@ -11,8 +12,8 @@ export type ScrollSnapsType = {
 export function ScrollSnaps(
   axis: AxisType,
   alignment: AlignmentType,
-  containerRect: DOMRect,
-  slideRects: DOMRect[],
+  containerRect: NodeRectType,
+  slideRects: NodeRectType[],
   slidesToScroll: SlidesToScrollType
 ): ScrollSnapsType {
   const { startEdge, endEdge } = axis

--- a/packages/embla-carousel/src/components/SlideSizes.ts
+++ b/packages/embla-carousel/src/components/SlideSizes.ts
@@ -1,4 +1,5 @@
 import { AxisType } from './Axis'
+import { NodeRectType } from './NodeRects'
 import { arrayIsLastIndex, arrayLast, mathAbs, WindowType } from './utils'
 
 export type SlideSizesType = {
@@ -10,8 +11,8 @@ export type SlideSizesType = {
 
 export function SlideSizes(
   axis: AxisType,
-  containerRect: DOMRect,
-  slideRects: DOMRect[],
+  containerRect: NodeRectType,
+  slideRects: NodeRectType[],
   slides: HTMLElement[],
   readEdgeGap: boolean,
   ownerWindow: WindowType

--- a/packages/embla-carousel/src/components/SlidesToScroll.ts
+++ b/packages/embla-carousel/src/components/SlidesToScroll.ts
@@ -1,5 +1,6 @@
 import { AxisType } from './Axis'
 import { DirectionType } from './Direction'
+import { NodeRectType } from './NodeRects'
 import {
   arrayKeys,
   arrayLast,
@@ -20,8 +21,8 @@ export function SlidesToScroll(
   viewSize: number,
   slidesToScroll: SlidesToScrollOptionType,
   loop: boolean,
-  containerRect: DOMRect,
-  slideRects: DOMRect[],
+  containerRect: NodeRectType,
+  slideRects: NodeRectType[],
   startGap: number,
   endGap: number
 ): SlidesToScrollType {

--- a/packages/embla-carousel/src/components/utils.ts
+++ b/packages/embla-carousel/src/components/utils.ts
@@ -88,23 +88,3 @@ export function isMouseEvent(
     evt instanceof ownerWindow.MouseEvent
   )
 }
-
-export function getNodeRect(node: HTMLElement): DOMRect {
-  const { offsetTop, offsetLeft, offsetWidth, offsetHeight } = node
-
-  const rect = {
-    top: offsetTop,
-    left: offsetLeft,
-    x: offsetLeft,
-    y: offsetTop,
-    width: offsetWidth,
-    height: offsetHeight,
-    bottom: offsetTop + offsetHeight,
-    right: offsetLeft + offsetWidth
-  }
-
-  return {
-    ...rect,
-    toJSON: () => rect
-  }
-}

--- a/packages/embla-carousel/src/components/utils.ts
+++ b/packages/embla-carousel/src/components/utils.ts
@@ -88,3 +88,23 @@ export function isMouseEvent(
     evt instanceof ownerWindow.MouseEvent
   )
 }
+
+export function getNodeRect(node: HTMLElement): DOMRect {
+  const { offsetTop, offsetLeft, offsetWidth, offsetHeight } = node
+
+  const rect = {
+    top: offsetTop,
+    left: offsetLeft,
+    x: offsetLeft,
+    y: offsetTop,
+    width: offsetWidth,
+    height: offsetHeight,
+    bottom: offsetTop + offsetHeight,
+    right: offsetLeft + offsetWidth
+  }
+
+  return {
+    ...rect,
+    toJSON: () => rect
+  }
+}


### PR DESCRIPTION
When using the carousel inside a container with a scale transform applied the carousel doesn't work properly because it uses to measure nodes getBoundingClientRect, which returns a rect which is already scaled.
The proposed fix (tested working in the playground) uses instead offsetLeft/offsetWidth etc, which are unscaled.