### PR TITLE
Add docs section in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,6 +24,26 @@ For any new features it's important to follow this checklist:
 - **`Code style:`** Follow the current code style as described [here](#code-style).
 - **`Create a Pull Request:`** Please make sure the branch name follows this pattern `feature/branchname-goes-here`.
 
+  
+### Documentation
+
+The documentation is generated using [gatspy](https://github.com/gatsbyjs/gatsby). All the content of the docs lives inside `/packages/embla-carousel-docs`. 
+
+To develop the docs locally follow these steps:
+
+- Install dependencies with `yarn install`
+- Run `yarn start` to start the dev enviornment of the docs in `localhost:8000`
+- Make sure the `.mdx` file you're working on has a header like this:
+```
+---
+title: [Page title here]
+description: [Page description here].
+order: [Page order here (a number)]
+date: [Page last updated date (e.g. 2023-12-20)]
+---
+```
+
+
 ### Code style
 
 All code contributions should follow the current `code style`. Please take your time to understand the current setup and don't introduce new styles that clearly deviates from the project `code style`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,8 @@ The documentation is generated using [gatspy](https://github.com/gatsbyjs/gatsby
 
 To develop the docs locally follow these steps:
 
-- Install dependencies with `yarn install`
+- Run `yarn install`in the root directory to install dependencies
+- Run `yarn build` to build the docs (and the other packages)
 - Run `yarn start` to start the dev enviornment of the docs in `localhost:8000`
 - Make sure the `.mdx` file you're working on has a header like this:
 ```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,9 @@ For any new features it's important to follow this checklist:
 
 The documentation is generated using [gatspy](https://github.com/gatsbyjs/gatsby). All the content of the docs lives inside `/packages/embla-carousel-docs`. 
 
+> [!IMPORTANT]  
+> Make sure your node version is equal to the one in [.nvmrc](https://github.com/davidjerleke/embla-carousel/blob/master/.nvmrc). You can use [`nvm`](https://github.com/nvm-sh/nvm) to easily install different node versions and switch between them with ease.
+
 To develop the docs locally follow these steps:
 
 - Run `yarn install`in the root directory to install dependencies

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for considering contributing to Embla Carousel, contributions are welc
 All bug reports require a reduced test case. Providing a test case is the best way to get any issue addressed. It helps us all to understand the problem. Without this, your issue **may be closed**. Please follow this checklist:
 
 - **`Test case:`** Create one by forking one of the CodeSandboxes on the [examples page](https://www.embla-carousel.com/examples/). If applicable, choose the most relevant one.
+- **`Test case exceptions:`** In rare cases a CodeSandbox might not be possible to provide. If this is the case, make sure to provide an alternative source like a GitHub repository or similar.
 - **`Demonstrate:`** Make sure the test case clearly demonstrates the issue.
 - **`Do not:`** Provide a link to a production site. That's not a test case.
 - **`Create a Pull Request:`** If you want to solve the bug yourself, please make sure the branch name follows this pattern `bug/branchname-goes-here`.
@@ -24,20 +25,20 @@ For any new features it's important to follow this checklist:
 - **`Code style:`** Follow the current code style as described [here](#code-style).
 - **`Create a Pull Request:`** Please make sure the branch name follows this pattern `feature/branchname-goes-here`.
 
-  
 ### Documentation
 
-The documentation is generated using [gatspy](https://github.com/gatsbyjs/gatsby). All the content of the docs lives inside `/packages/embla-carousel-docs`. 
+The documentation website is generated using [gatsby](https://github.com/gatsbyjs/gatsby). All the content of the docs lives inside [`/packages/embla-carousel-docs`](https://github.com/davidjerleke/embla-carousel/tree/master/packages/embla-carousel-docs).
 
 > [!IMPORTANT]  
 > Make sure your node version is equal to the one in [.nvmrc](https://github.com/davidjerleke/embla-carousel/blob/master/.nvmrc). You can use [`nvm`](https://github.com/nvm-sh/nvm) to easily install different node versions and switch between them with ease.
 
 To develop the docs locally follow these steps:
 
-- Run `yarn install`in the root directory to install dependencies
-- Run `yarn build` to build the docs (and the other packages)
-- Run `yarn start` to start the dev enviornment of the docs in `localhost:8000`
-- Make sure the `.mdx` file you're working on has a header like this:
+- Run `yarn install`in the root directory to install dependencies.
+- Run `yarn build` to build the docs (and all other packages).
+- Run `yarn start` to start the dev environment of the docs at `localhost:8000`.
+- Make sure the `.mdx` file you're working on has a header formatted like this:
+
 ```
 ---
 title: [Page title here]
@@ -46,7 +47,6 @@ order: [Page order here (a number)]
 date: [Page last updated date (e.g. 2023-12-20)]
 ---
 ```
-
 
 ### Code style
 


### PR DESCRIPTION
Added a `documentation` section in the CONTRIBUTING.md file to guide people on how to run the docs locally to hopefully streamline the process of updating the docs when needed.