### PR TITLE
Added `embla-carousel` as a dependency for CodeSandbox template

### DIFF
--- a/packages/embla-carousel-docs/package.json
+++ b/packages/embla-carousel-docs/package.json
@@ -38,6 +38,7 @@
     "@mdx-js/react": "^2.2.1",
     "babel-plugin-styled-components": "^2.0.2",
     "codesandbox": "^2.2.3",
+    "embla-carousel": "8.0.0-rc19",
     "embla-carousel-autoplay": "8.0.0-rc19",
     "embla-carousel-class-names": "8.0.0-rc19",
     "embla-carousel-react": "8.0.0-rc19",

--- a/packages/embla-carousel-docs/src/components/Sandbox/React/createSandboxReactPackageJson.ts
+++ b/packages/embla-carousel-docs/src/components/Sandbox/React/createSandboxReactPackageJson.ts
@@ -34,6 +34,7 @@ export const createSandboxReactPackageJson = async (
       'react-dom': dependencies['react-dom'],
       'react-scripts': '4.0.0',
       'embla-carousel-react': dependencies['embla-carousel-react'],
+      'embla-carousel': dependencies['embla-carousel'],
       ...(plugins && plugins)
     },
     devDependencies: isJavaScript

--- a/yarn.lock
+++ b/yarn.lock
@@ -8804,6 +8804,7 @@ __metadata:
     "@typescript-eslint/parser": ^6.9.0
     babel-plugin-styled-components: ^2.0.2
     codesandbox: ^2.2.3
+    embla-carousel: 8.0.0-rc19
     embla-carousel-autoplay: 8.0.0-rc19
     embla-carousel-class-names: 8.0.0-rc19
     embla-carousel-react: 8.0.0-rc19


### PR DESCRIPTION
Fixes #684

I had to add `embla-carousel` as a dependency of `embla-carousel-docs` so that it can be used in `createSandboxReactPackageJson.ts` dynamically