### PR TITLE
[Feat]: For Vue docs, use a more common SFC format

### DIFF
--- a/packages/embla-carousel-docs/src/components/Mdx/Components/PrismSyntaxHighlight.tsx
+++ b/packages/embla-carousel-docs/src/components/Mdx/Components/PrismSyntaxHighlight.tsx
@@ -2,50 +2,13 @@ import React, { useMemo } from 'react'
 import { PrismSyntaxFrame } from './PrismSyntaxFrame'
 import Highlight, { defaultProps } from 'prism-react-renderer'
 import {
+  parseCodeBlockProps,
+  parseHighlightedLines
+} from 'utils/prismHighlight'
+import {
   PRISM_HIGHLIGHT_CLASS_NAME,
-  PRISM_HIGHLIGHT_LINE_CLASS_NAME,
-  PRISM_HIGHLIGHT_PROP_SEPARATOR,
-  PrismCodeBlockPropsType
+  PRISM_HIGHLIGHT_LINE_CLASS_NAME
 } from 'consts/prismHighlight'
-
-const REGEX_HIGHLIGHT_RANGE = /\d{1,}-\d{1,}/
-const REGEX_HIGHLIGHT_RANGE_END = /-\d{1,}/
-const REGEX_HIGHLIGHT_RANGE_START = /\d{1,}-/
-const REGEX_LANGUAGE_PREFIX = /language-/gm
-
-const parseHighlightedLines = (highlight: string = ''): number[] => {
-  const highlightedLines: number[] = []
-  const matches = highlight.replace(/{|}/g, '').split(',')
-
-  return matches.reduce((highlightedLinesArray, match) => {
-    if (REGEX_HIGHLIGHT_RANGE.test(match)) {
-      const start = parseInt(match.replace(REGEX_HIGHLIGHT_RANGE_END, ''), 10)
-      const end = parseInt(match.replace(REGEX_HIGHLIGHT_RANGE_START, ''), 10)
-
-      for (let i = start; i <= end; i += 1) highlightedLinesArray.push(i)
-    } else if (/\d{1,}/.test(match)) {
-      highlightedLinesArray.push(parseInt(match, 10))
-    }
-    return highlightedLinesArray
-  }, highlightedLines)
-}
-
-const parseCodeBlockProps = (string: string): PrismCodeBlockPropsType => {
-  return string
-    .split(PRISM_HIGHLIGHT_PROP_SEPARATOR)
-    .reduce((props, propString, index) => {
-      if (index === 0) {
-        const language = propString.replace(REGEX_LANGUAGE_PREFIX, '')
-        return { language }
-      }
-
-      const [prop, value] = propString.split('=')
-      return {
-        ...props,
-        [prop]: value
-      }
-    }, {}) as PrismCodeBlockPropsType
-}
 
 type PropType = {
   children: string

--- a/packages/embla-carousel-docs/src/content/pages/api/events.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/events.mdx
@@ -63,26 +63,22 @@ After initializing a carousel, we're going to **subscribe** to the [select](/api
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={14}
-    <script>
+    ```html highlight={12}
+    <script setup>
       import { watchEffect } from 'vue'
       import emblaCarouselVue from 'embla-carousel-vue'
 
-      export default {
-        setup() {
-          const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
+      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
 
-          const onSelect = (emblaApi, eventName) => {
-            console.log(`Embla just triggered ${eventName}!`)
-          }
-
-          watchEffect(() => {
-            if (emblaApi.value) emblaApi.value.on('select', onSelect)
-          })
-
-          // ...
-        }
+      const onSelect = (emblaApi, eventName) => {
+        console.log(`Embla just triggered ${eventName}!`)
       }
+
+      watchEffect(() => {
+        if (emblaApi.value) emblaApi.value.on('select', onSelect)
+      })
+
+      // ...
     </script>
     ```
 
@@ -141,30 +137,26 @@ In order to remove an event listener, you'll have to call the [off](/api/methods
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={13-15}
-    <script>
+    ```html highlight={11-13}
+    <script setup>
       import { watchEffect } from 'vue'
       import emblaCarouselVue from 'embla-carousel-vue'
 
-      export default {
-        setup() {
-          const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
+      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
 
-          const onSelect = (emblaApi, eventName) => {
-            console.log(`Embla just triggered ${eventName}!`)
-          }
-
-          const removeOnSelectListener = () => {
-            if (emblaApi.value) emblaApi.value.off('select', onSelect)
-          }
-
-          watchEffect(() => {
-            if (emblaApi.value) emblaApi.value.on('select', onSelect)
-          })
-
-          // ...
-        }
+      const onSelect = (emblaApi, eventName) => {
+        console.log(`Embla just triggered ${eventName}!`)
       }
+
+      const removeOnSelectListener = () => {
+        if (emblaApi.value) emblaApi.value.off('select', onSelect)
+      }
+
+      watchEffect(() => {
+        if (emblaApi.value) emblaApi.value.on('select', onSelect)
+      })
+
+      // ...
     </script>
     ```
 
@@ -233,7 +225,7 @@ The `EmblaEventType` is obtained directly from the **core package** `embla-carou
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
     ```html highlight={3,10}
-    <script lang="ts">
+    <script setup>
       import { watchEffect } from 'vue'
       import { EmblaCarouselType, EmblaEventType } from 'embla-carousel'
       import emblaCarouselVue from 'embla-carousel-vue'

--- a/packages/embla-carousel-docs/src/content/pages/api/methods.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/methods.mdx
@@ -41,7 +41,7 @@ In the following example, the [slideNodes](/api/methods/#slidenodes) method is c
     import { useEffect } from 'react'
     import useEmblaCarousel from 'embla-carousel-react'
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true })
 
       useEffect(() => {
@@ -55,22 +55,18 @@ In the following example, the [slideNodes](/api/methods/#slidenodes) method is c
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={10}
-    <script>
+    ```html highlight={8}
+    <script setup>
       import { watchEffect } from 'vue'
       import emblaCarouselVue from 'embla-carousel-vue'
 
-      export default {
-        setup() {
-          const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
+      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true })
 
-          watchEffect(() => {
-            if (emblaApi.value) console.log(emblaApi.value.slideNodes())
-          })
+      watchEffect(() => {
+        if (emblaApi.value) console.log(emblaApi.value.slideNodes())
+      })
 
-          // ...
-        }
-      }
+      // ...
     </script>
     ```
 
@@ -130,7 +126,7 @@ The `EmblaCarouselType` is obtained directly from the **core package** `embla-ca
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
     ```html highlight={3,8}
-    <script lang="ts" setup>
+    <script setup lang="ts">
       import { watchEffect } from 'vue'
       import { EmblaCarouselType } from 'embla-carousel'
       import emblaCarouselVue from 'embla-carousel-vue'

--- a/packages/embla-carousel-docs/src/content/pages/api/options.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/options.mdx
@@ -38,7 +38,7 @@ The constructor options is the default way of providing options to Embla Carouse
     ```jsx highlight={4}
     import useEmblaCarousel from 'embla-carousel-react'
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef] = useEmblaCarousel({ loop: true })
       // ...
     }
@@ -88,7 +88,7 @@ Setting **global options** will be applied to **all carousels** which will overr
 
     useEmblaCarousel.globalOptions = { loop: true }
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef] = useEmblaCarousel({ align: 'center' })
       // ...
     }
@@ -159,7 +159,7 @@ The `EmblaOptionsType` is obtained directly from the **core package** `embla-car
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
     ```html highlight={2,5}
-    <script lang="ts" setup>
+    <script setup lang="ts">
       import { EmblaOptionsType } from 'embla-carousel'
       import emblaCarouselVue from 'embla-carousel-vue'
 

--- a/packages/embla-carousel-docs/src/content/pages/api/plugins.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/plugins.mdx
@@ -40,7 +40,7 @@ The constructor plugin array is the default way of providing plugins to Embla Ca
     import useEmblaCarousel from 'embla-carousel-react'
     import Autoplay from 'embla-carousel-autoplay'
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef] = useEmblaCarousel({ loop: true }, [Autoplay()])
       // ...
     }
@@ -49,17 +49,13 @@ The constructor plugin array is the default way of providing plugins to Embla Ca
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={7}
-    <script>
+    ```html highlight={5}
+    <script setup>
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'
 
-      export default {
-        setup() {
-          const [emblaNode] = emblaCarouselVue({ loop: true }, [Autoplay()])
-          // ...
-        }
-      }
+      const [emblaNode] = emblaCarouselVue({ loop: true }, [Autoplay()])
+      // ...
     </script>
     ```
 
@@ -95,7 +91,7 @@ Plugins have their own specific **options** which is the first argument of the p
     import useEmblaCarousel from 'embla-carousel-react'
     import Autoplay from 'embla-carousel-autoplay'
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef] = useEmblaCarousel({ loop: true }, [
         Autoplay({ delay: 4000 })
       ])
@@ -106,19 +102,15 @@ Plugins have their own specific **options** which is the first argument of the p
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={8}
-    <script>
+    ```html highlight={6}
+    <script setup>
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'
 
-      export default {
-        setup() {
-          const [emblaNode] = emblaCarouselVue({ loop: true }, [
-            Autoplay({ delay: 4000 })
-          ])
-          // ...
-        }
-      }
+      const [emblaNode] = emblaCarouselVue({ loop: true }, [
+        Autoplay({ delay: 4000 })
+      ])
+      // ...
     </script>
     ```
 
@@ -150,7 +142,7 @@ All [official plugins](/plugins/) allows you to set **global options** that will
 
     Autoplay.globalOptions = { delay: 4000 }
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef] = useEmblaCarousel({ loop: true }, [Autoplay()])
       // ...
     }
@@ -160,18 +152,14 @@ All [official plugins](/plugins/) allows you to set **global options** that will
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
     ```html highlight={5}
-    <script>
+    <script setup>
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'
 
       Autoplay.globalOptions = { delay: 4000 }
 
-      export default {
-        setup() {
-          const [emblaNode] = emblaCarouselVue({ loop: true }, [Autoplay()])
-          // ...
-        }
-      }
+      const [emblaNode] = emblaCarouselVue({ loop: true }, [Autoplay()])
+      // ...
     </script>
     ```
 
@@ -208,7 +196,7 @@ Additionally, some plugins expose their own **API methods**. You can access plug
     import useEmblaCarousel from 'embla-carousel-react'
     import Autoplay from 'embla-carousel-autoplay'
 
-    export const EmblaCarousel = () => {
+    export function EmblaCarousel() {
       const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true }, [Autoplay()])
 
       useEffect(() => {
@@ -222,25 +210,21 @@ Additionally, some plugins expose their own **API methods**. You can access plug
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={13}
-    <script>
+    ```html highlight={11}
+    <script setup>
       import { watchEffect } from 'vue'
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'
 
-      export default {
-        setup() {
-          const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true }, [
-            Autoplay()
-          ])
+      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true }, [
+        Autoplay()
+      ])
 
-          watchEffect(() => {
-            if (emblaApi.value) emblaApi.value.plugins().autoplay.stop()
-          })
+      watchEffect(() => {
+        if (emblaApi.value) emblaApi.value.plugins().autoplay.stop()
+      })
 
-          // ...
-        }
-      }
+      // ...
     </script>
     ```
 
@@ -295,31 +279,27 @@ Some plugins fire their own **events**. Plugin events are structured as follows 
   </TabsItem>
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
-    ```html highlight={18}
-    <script>
+    ```html highlight={16}
+    <script setup>
       import { watchEffect, onBeforeUnmount } from 'vue'
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'
 
-      export default {
-        setup() {
-          const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true }, [
-            Autoplay()
-          ])
+      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: true }, [
+        Autoplay()
+      ])
 
-          function logAutoplayStopEvent() {
-            console.log('Autoplay plugin stopped playing!')
-          }
-
-          watchEffect(() => {
-            if (emblaApi.value) {
-              emblaApi.value.on('autoplay:stop', logAutoplayStopEvent) // add
-            }
-          })
-
-          // ...
-        }
+      function logAutoplayStopEvent() {
+        console.log('Autoplay plugin stopped playing!')
       }
+
+      watchEffect(() => {
+        if (emblaApi.value) {
+          emblaApi.value.on('autoplay:stop', logAutoplayStopEvent) // add
+        }
+      })
+
+      // ...
     </script>
     ```
 
@@ -373,7 +353,7 @@ The `EmblaPluginType` is obtained directly from the **core package** `embla-caro
   <TabsItem tab={TABS_LIBRARY.TABS.VUE}>
 
     ```html highlight={2,7}
-    <script lang="ts" setup>
+    <script setup lang="ts">
       import { EmblaOptionsType, EmblaPluginType } from 'embla-carousel'
       import emblaCarouselVue from 'embla-carousel-vue'
       import Autoplay from 'embla-carousel-autoplay'

--- a/packages/embla-carousel-docs/src/content/pages/get-started/react.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/get-started/react.mdx
@@ -40,7 +40,7 @@ Embla Carousel provides the handy `useEmblaCarousel` hook for seamless integrati
 import React from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 
-export const EmblaCarousel = () => {
+export function EmblaCarousel() {
   const [emblaRef] = useEmblaCarousel()
 
   return (
@@ -80,7 +80,7 @@ The `useEmblaCarousel` hook takes the Embla Carousel [options](/api/options/) as
 import React, { useEffect } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 
-export const EmblaCarousel = () => {
+export function EmblaCarousel() {
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false })
 
   useEffect(() => {
@@ -129,7 +129,7 @@ import React, { useEffect } from 'react'
 import useEmblaCarousel from 'embla-carousel-react'
 import Autoplay from 'embla-carousel-autoplay'
 
-export const EmblaCarousel = () => {
+export function EmblaCarousel() {
   const [emblaRef] = useEmblaCarousel({ loop: false }, [Autoplay()])
 
   return (

--- a/packages/embla-carousel-docs/src/content/pages/get-started/vue.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/get-started/vue.mdx
@@ -37,6 +37,12 @@ Start by installing the Embla Carousel **npm package** and add it to your depend
 Embla Carousel provides the handy `emblaCarouselVue` function for seamless integration with Vue. A minimal setup requires an **overflow wrapper** and a **scroll container**. Start by adding the following structure to your carousel:
 
 ```html
+<script setup>
+  import emblaCarouselVue from 'embla-carousel-vue'
+
+  const [emblaNode] = emblaCarouselVue()
+</script>
+
 <template>
   <div class="embla" ref="emblaNode">
     <div class="embla__container">
@@ -46,17 +52,6 @@ Embla Carousel provides the handy `emblaCarouselVue` function for seamless integ
     </div>
   </div>
 </template>
-
-<script>
-  import emblaCarouselVue from 'embla-carousel-vue'
-
-  export default {
-    setup() {
-      const [emblaNode] = emblaCarouselVue()
-      return { emblaNode }
-    }
-  }
-</script>
 ```
 
 ## Styling the carousel
@@ -82,7 +77,20 @@ The `emblaCarouselVue` function gives us an **emblaNode** to attach to our wrapp
 
 The `emblaCarouselVue` function takes the Embla Carousel [options](/api/options/) as the first argument. Additionally, you can access the [API](/api/) with an `watchEffect` like demonstrated below:
 
-```html highlight={17,19-23}
+```html highlight={5,7-11}
+<script setup>
+  import { watchEffect } from 'vue'
+  import emblaCarouselVue from 'embla-carousel-vue'
+
+  const [emblaNode, emblaApi] = emblaCarouselVue({ loop: false })
+
+  watchEffect(() => {
+    if (emblaApi.value) {
+      console.log(emblaApi.value.slideNodes()) // Access API
+    }
+  })
+</script>
+
 <template>
   <div class="embla" ref="emblaNode">
     <div class="embla__container">
@@ -92,25 +100,6 @@ The `emblaCarouselVue` function takes the Embla Carousel [options](/api/options/
     </div>
   </div>
 </template>
-
-<script>
-  import { watchEffect } from 'vue'
-  import emblaCarouselVue from 'embla-carousel-vue'
-
-  export default {
-    setup() {
-      const [emblaNode, emblaApi] = emblaCarouselVue({ loop: false })
-
-      watchEffect(() => {
-        if (emblaApi.value) {
-          console.log(emblaApi.value.slideNodes()) // Access API
-        }
-      })
-
-      return { emblaNode, emblaApi }
-    }
-  }
-</script>
 ```
 
 ## Adding plugins
@@ -136,7 +125,14 @@ Start by installing the plugin you want to use. In this example, we're going to 
 
 The `emblaCarouselVue` function accepts [plugins](/plugins/) as the second argument. Note that plugins need to be passed in an **array** like so:
 
-```html highlight={13,17}
+```html highlight={3,5}
+<script setup>
+  import emblaCarouselVue from 'embla-carousel-vue'
+  import Autoplay from 'embla-carousel-autoplay'
+
+  const [emblaNode] = emblaCarouselVue({ loop: false }, [Autoplay()])
+</script>
+
 <template>
   <div class="embla" ref="emblaNode">
     <div class="embla__container">
@@ -146,18 +142,6 @@ The `emblaCarouselVue` function accepts [plugins](/plugins/) as the second argum
     </div>
   </div>
 </template>
-
-<script>
-  import emblaCarouselVue from 'embla-carousel-vue'
-  import Autoplay from 'embla-carousel-autoplay'
-
-  export default {
-    setup() {
-      const [emblaNode] = emblaCarouselVue({ loop: false }, [Autoplay()])
-      return { emblaNode }
-    }
-  }
-</script>
 ```
 
 Congratulations! You just created your first Embla Carousel component.

--- a/packages/embla-carousel-docs/src/utils/prismHighlight.ts
+++ b/packages/embla-carousel-docs/src/utils/prismHighlight.ts
@@ -1,0 +1,45 @@
+import {
+  PRISM_HIGHLIGHT_PROP_SEPARATOR,
+  PrismCodeBlockPropsType
+} from 'consts/prismHighlight'
+
+const REGEX_HIGHLIGHT_RANGE = /\d{1,}-\d{1,}/
+const REGEX_HIGHLIGHT_RANGE_END = /-\d{1,}/
+const REGEX_HIGHLIGHT_RANGE_START = /\d{1,}-/
+const REGEX_LANGUAGE_PREFIX = /language-/gm
+
+export const parseHighlightedLines = (highlight: string = ''): number[] => {
+  const highlightedLines: number[] = []
+  const matches = highlight.replace(/{|}/g, '').split(',')
+
+  return matches.reduce((highlightedLinesArray, match) => {
+    if (REGEX_HIGHLIGHT_RANGE.test(match)) {
+      const start = parseInt(match.replace(REGEX_HIGHLIGHT_RANGE_END, ''), 10)
+      const end = parseInt(match.replace(REGEX_HIGHLIGHT_RANGE_START, ''), 10)
+
+      for (let i = start; i <= end; i += 1) highlightedLinesArray.push(i)
+    } else if (/\d{1,}/.test(match)) {
+      highlightedLinesArray.push(parseInt(match, 10))
+    }
+    return highlightedLinesArray
+  }, highlightedLines)
+}
+
+export const parseCodeBlockProps = (
+  string: string
+): PrismCodeBlockPropsType => {
+  return string
+    .split(PRISM_HIGHLIGHT_PROP_SEPARATOR)
+    .reduce((props, propString, index) => {
+      if (index === 0) {
+        const language = propString.replace(REGEX_LANGUAGE_PREFIX, '')
+        return { language }
+      }
+
+      const [prop, value] = propString.split('=')
+      return {
+        ...props,
+        [prop]: value
+      }
+    }, {}) as PrismCodeBlockPropsType
+}


### PR DESCRIPTION
- Closes: #700.

### Feature description

To use a format for Vue Single File Components (SFCs) that is more succint and commonly used by the Vue community.

As per what is shown in the [Introduction page of the Vue docs](https://vuejs.org/guide/introduction.html):
1. `<script setup>` is more commonly used, and 
2. `<script setup>` -> `<template>` -> `<style scoped>` order is more common

Here's the current example found in the docs:
```vue
<template>
  <div class="embla" ref="emblaNode">
    <div class="embla__container">
      <div class="embla__slide">Slide 1</div>
      <div class="embla__slide">Slide 2</div>
      <div class="embla__slide">Slide 3</div>
    </div>
  </div>
</template>

<script>
  import emblaCarouselVue from 'embla-carousel-vue'

  export default {
    setup() {
      const [emblaNode] = emblaCarouselVue()
      return { emblaNode }
    }
  }
</script>
```

And here's the _proposed change_ in format - less verbose, more commonly used:
```vue
<script setup>
import emblaCarouselVue from 'embla-carousel-vue'

const [emblaNode] = emblaCarouselVue()
</script>

<template>
  <div class="embla" ref="emblaNode">
    <div class="embla__container">
      <div class="embla__slide">Slide 1</div>
      <div class="embla__slide">Slide 2</div>
      <div class="embla__slide">Slide 3</div>
    </div>
  </div>
</template>
```