### PR TITLE
Update 'events' Typescript example useEffect deps

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/api/events.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/events.mdx
@@ -294,7 +294,7 @@ export function EmblaCarousel() {
 
   useEffect(() => {
     if (emblaApi) emblaApi.on('slidesInView', logEmblaEvent)
-  }, [logEmblaEvent])
+  }, [emblaApi, logEmblaEvent])
 
   // ...
 }


### PR DESCRIPTION
The example is never run, if emblaApi is not added as a dependancy to the useEffect