### PR TITLE
[Feat]: Add RTL case for slide gaps via CSS in docs

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/guides/slide-gaps.md
+++ b/packages/embla-carousel-docs/src/content/pages/guides/slide-gaps.md
@@ -30,6 +30,15 @@ It's also valid to add gaps in both directions:
 }
 ```
 
+If you want to accomodate for RTL languages, you can use [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) and [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) instead:
+
+```css
+.embla__slide {
+  margin-inline-end: 20px; /* Space after the slide */
+  margin-inline-start: 10px; /* Space before the slide */
+}
+```
+
 If you're using CSS Grid you can declare your gaps like so:
 
 ```css


### PR DESCRIPTION
Hi @davidjerleke,

Hope you're doing well. 

This PR is a simple addition to the [slide-gaps](https://www.embla-carousel.com/guides/slide-gaps/) section of the docs to mention the RTL case.

Let me know If I missed something 

Best,
Zakher