### PR TITLE
bug fix: render when slides are wider than view size

### DIFF
--- a/packages/embla-carousel/src/__tests__/slidesToScroll-ltr.test.ts
+++ b/packages/embla-carousel/src/__tests__/slidesToScroll-ltr.test.ts
@@ -8,6 +8,47 @@ import {
 
 const FIRST_SNAP_INDEX = 0
 
+describe('➡️  SlidesToScroll - Horizontal LTR - Wide slides', () => {
+  describe('"auto" is correct for wide slides WITHOUT MARGINS and:', () => {
+    const emblaApi = EmblaCarousel(
+      mockTestElements({
+        ...FIXTURE_SLIDES_TO_SCROLL_LTR_1,
+        containerOffset: {
+          offsetWidth: 250,
+          offsetHeight: 190,
+          offsetTop: 0,
+          offsetLeft: 0
+        }
+      })
+    )
+
+    beforeEach(() => {
+      emblaApi.reInit({ ...defaultOptions, slidesToScroll: 'auto' })
+    })
+
+    test('LOOP:FALSE', () => {
+      const engine = emblaApi.internalEngine()
+      const expectedScrollSnaps = [
+        0, -625, -1000, -1250, -1500, -1750, -2125, -2625, -3125, -3751
+      ]
+      expect(engine.scrollSnaps).toEqual(expectedScrollSnaps)
+      expect(engine.location.get()).toBe(expectedScrollSnaps[FIRST_SNAP_INDEX])
+      expect(engine.slideRegistry).toEqual([
+        [0],
+        [1],
+        [2],
+        [3],
+        [4],
+        [5],
+        [6],
+        [7],
+        [8],
+        [9]
+      ])
+    })
+  })
+})
+
 describe('➡️  SlidesToScroll - Horizontal LTR', () => {
   describe('"auto" is correct for slides WITHOUT MARGINS and:', () => {
     const emblaApi = EmblaCarousel(

--- a/packages/embla-carousel/src/components/SlidesToScroll.ts
+++ b/packages/embla-carousel/src/components/SlidesToScroll.ts
@@ -38,7 +38,7 @@ export function SlidesToScroll(
     if (!array.length) return []
 
     return arrayKeys(array)
-      .reduce((groups: number[], rectB) => {
+      .reduce((groups: number[], rectB, index) => {
         const rectA = arrayLast(groups) || 0
         const isFirst = rectA === 0
         const isLast = rectB === arrayLastIndex(array)
@@ -49,7 +49,8 @@ export function SlidesToScroll(
         const gapB = !loop && isLast ? direction(endGap) : 0
         const chunkSize = mathAbs(edgeB - gapB - (edgeA + gapA))
 
-        if (chunkSize > viewSize + pixelTolerance) groups.push(rectB)
+        if (index !== 0 && chunkSize > viewSize + pixelTolerance)
+          groups.push(rectB)
         if (isLast) groups.push(array.length)
         return groups
       }, [])


### PR DESCRIPTION
Hi David,

Thanks for a great library. You efforts are much appreciated.

This PR addresses an issue I ran into - when the first slide is wider than the view size, an exception is thrown. This happens because of an underlying assumption when creating scroll groups by size (see test case).

Happy to make additional changes if any suggestions.