### PR TITLE
chore(docs): note about Vue 2 support

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/get-started/vue.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/get-started/vue.mdx
@@ -30,6 +30,12 @@ Start by installing the Embla Carousel **npm package** and add it to your depend
   </TabsItem>
 </Tabs>
 
+<Admonition type="note">
+**Note:** `embla-carousel-vue` only supports `Vue 3` and up.
+However, you can use the [vanilla version](/module/) and re-create the behaviour of `embla-carousel-vue`.
+[Here's an example](https://github.com/meirroth/embla-carousel-vue2) of how you can use Embla Carousel with `Vue 2` Options API.
+</Admonition>
+
 ---
 
 ## The component structure


### PR DESCRIPTION
This PR adds information on the Vue versions `embla-carousel-vue` supports. And hopefully helps anyone wanting to use this carousel with Vue 2.
Let me know if you prefer it links to an example repo internally, as supposed to the one under my account.


- Rel #842 