### PR TITLE
Add better error message for missing mocks

### DIFF
--- a/packages/embla-carousel/src/components/OptionsHandler.ts
+++ b/packages/embla-carousel/src/components/OptionsHandler.ts
@@ -31,6 +31,9 @@ export function OptionsHandler(ownerWindow: WindowType): OptionsHandlerType {
   }
 
   function optionsMediaQueries(optionsList: OptionsType[]): MediaQueryList[] {
+    if (!('matchMedia' in ownerWindow)) {
+      throw new Error('matchMedia does not exist on window, mock it if running tests')
+    }
     return optionsList
       .map((options) => objectKeys(options.breakpoints || {}))
       .reduce((acc, mediaQueries) => acc.concat(mediaQueries), [])


### PR DESCRIPTION
Right now it's hard to figure out what's wrong here:
![Screenshot 2024-05-17 at 13 01 09](https://github.com/davidjerleke/embla-carousel/assets/10765158/5995a8eb-88c7-44c5-a333-529a148a2e33)
"undefined is not a function"

Almost everyone will run into this after upgrading to the new major version. Maybe we could add a better error message.
Perhaps linking to [this comment](https://github.com/davidjerleke/embla-carousel/issues/837#issuecomment-2073969586) or directly to the mocks.

Looking at caniuse stats, it's pretty unrealistic that people will run into these errors unless running tests.
What do you think?
