### PR TITLE
embla-carousel-auto-height | Start using ResizeObserver for height calculations

### DIFF
--- a/packages/embla-carousel-auto-height/src/components/AutoHeight.ts
+++ b/packages/embla-carousel-auto-height/src/components/AutoHeight.ts
@@ -14,6 +14,7 @@ export type AutoHeightOptionsType = AutoHeightType['options']
 
 function AutoHeight(userOptions: AutoHeightOptionsType = {}): AutoHeightType {
   let emblaApi: EmblaCarouselType
+  let resizeObserver: ResizeObserver
   let slideHeights: number[] = []
   const heightEvents: EmblaEventType[] = ['select', 'slideFocus']
 
@@ -21,22 +22,33 @@ function AutoHeight(userOptions: AutoHeightOptionsType = {}): AutoHeightType {
     emblaApi = emblaApiInstance
 
     const {
-      options: { axis },
-      slideRects
+      options: { axis }
     } = emblaApi.internalEngine()
 
     if (axis === 'y') return
 
-    slideHeights = slideRects.map((slideRect) => slideRect.height)
+    resizeObserver = new ResizeObserver(synchronizeSlideHeights)
+
+    emblaApi.slideNodes().forEach((node: HTMLElement) => {
+      resizeObserver.observe(node)
+    })
 
     heightEvents.forEach((evt) => emblaApi.on(evt, setContainerHeight))
-    setContainerHeight()
+
+    synchronizeSlideHeights()
   }
 
   function destroy(): void {
+    emblaApi.slideNodes().forEach((node: HTMLElement) => {
+      resizeObserver.unobserve(node)
+    })
+
     heightEvents.forEach((evt) => emblaApi.off(evt, setContainerHeight))
+
     const container = emblaApi.containerNode()
+
     container.style.height = ''
+
     if (!container.getAttribute('style')) container.removeAttribute('style')
   }
 
@@ -51,6 +63,14 @@ function AutoHeight(userOptions: AutoHeightOptionsType = {}): AutoHeightType {
 
   function setContainerHeight(): void {
     emblaApi.containerNode().style.height = `${highestInView()}px`
+  }
+
+  function synchronizeSlideHeights(): void {
+    const slideNodes = emblaApi.slideNodes()
+
+    slideHeights = slideNodes.map((node: HTMLElement) => node.offsetHeight)
+
+    setContainerHeight()
   }
 
   const self: AutoHeightType = {


### PR DESCRIPTION
## Context

After an initial investigation, have noticed that the `slideHeights` element for `embla-carousel-auto-height` was being calculated only when initializing the plugin, which does not detect dynamic changes to the carousel elements

The proposed solution leverages [ResizeObsevers](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe) to detect changes to the slide heights and re-calculate them properly

Solving https://github.com/davidjerleke/embla-carousel/issues/910

## Additional Details

ResizeObservers do have relevant coverage with all [major browsers](https://caniuse.com/resizeobserver), being a good candidate for the solution. Open for new ideas as always on how we could increase support