### PR TITLE
refactor(vue): optimize reactivity handling and reduce bundle size

### DIFF
--- a/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
+++ b/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
@@ -1,4 +1,4 @@
-import { Ref, ref, isRef, watch, onMounted, onBeforeUnmount } from 'vue'
+import { Ref, isRef, watch, onMounted, onBeforeUnmount, shallowRef } from 'vue'
 import {
   areOptionsEqual,
   arePluginsEqual,
@@ -19,10 +19,10 @@ function emblaCarouselVue(
   options: EmblaOptionsType | Ref<EmblaOptionsType> = {},
   plugins: EmblaPluginType[] | Ref<EmblaPluginType[]> = []
 ): EmblaCarouselVueType {
-  const storedOptions = ref(isRef(options) ? options.value : options)
-  const storedPlugins = ref(isRef(plugins) ? plugins.value : plugins)
-  const emblaNode = ref<HTMLElement>()
-  const emblaApi = ref<EmblaCarouselType>()
+  const storedOptions = shallowRef(isRef(options) ? options.value : options)
+  const storedPlugins = shallowRef(isRef(plugins) ? plugins.value : plugins)
+  const emblaNode = shallowRef<HTMLElement>()
+  const emblaApi = shallowRef<EmblaCarouselType>()
 
   function reInit() {
     if (!emblaApi.value) return

--- a/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
+++ b/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
@@ -1,4 +1,12 @@
-import { Ref, isRef, watch, onMounted, onBeforeUnmount, shallowRef } from 'vue'
+import {
+  Ref,
+  MaybeRef,
+  isRef,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  shallowRef
+} from 'vue'
 import {
   areOptionsEqual,
   arePluginsEqual,
@@ -16,8 +24,8 @@ export type EmblaCarouselVueType = [
 ]
 
 function emblaCarouselVue(
-  options: EmblaOptionsType | Ref<EmblaOptionsType> = {},
-  plugins: EmblaPluginType[] | Ref<EmblaPluginType[]> = []
+  options: MaybeRef<EmblaOptionsType> = {},
+  plugins: MaybeRef<EmblaPluginType[]> = []
 ): EmblaCarouselVueType {
   const isRefOptions = isRef(options)
   const isRefPlugins = isRef(plugins)

--- a/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
+++ b/packages/embla-carousel-vue/src/components/emblaCarouselVue.ts
@@ -19,14 +19,18 @@ function emblaCarouselVue(
   options: EmblaOptionsType | Ref<EmblaOptionsType> = {},
   plugins: EmblaPluginType[] | Ref<EmblaPluginType[]> = []
 ): EmblaCarouselVueType {
-  const storedOptions = shallowRef(isRef(options) ? options.value : options)
-  const storedPlugins = shallowRef(isRef(plugins) ? plugins.value : plugins)
+  const isRefOptions = isRef(options)
+  const isRefPlugins = isRef(plugins)
+
+  let storedOptions = isRefOptions ? options.value : options
+  let storedPlugins = isRefPlugins ? plugins.value : plugins
+
   const emblaNode = shallowRef<HTMLElement>()
   const emblaApi = shallowRef<EmblaCarouselType>()
 
   function reInit() {
     if (!emblaApi.value) return
-    emblaApi.value.reInit(storedOptions.value, storedPlugins.value)
+    emblaApi.value.reInit(storedOptions, storedPlugins)
   }
 
   onMounted(() => {
@@ -34,8 +38,8 @@ function emblaCarouselVue(
     EmblaCarousel.globalOptions = emblaCarouselVue.globalOptions
     emblaApi.value = EmblaCarousel(
       emblaNode.value,
-      storedOptions.value,
-      storedPlugins.value
+      storedOptions,
+      storedPlugins
     )
   })
 
@@ -43,18 +47,18 @@ function emblaCarouselVue(
     if (emblaApi.value) emblaApi.value.destroy()
   })
 
-  if (isRef(options)) {
+  if (isRefOptions) {
     watch(options, (newOptions) => {
-      if (areOptionsEqual(storedOptions.value, newOptions)) return
-      storedOptions.value = newOptions
+      if (areOptionsEqual(storedOptions, newOptions)) return
+      storedOptions = newOptions
       reInit()
     })
   }
 
-  if (isRef(plugins)) {
+  if (isRefPlugins) {
     watch(plugins, (newPlugins) => {
-      if (arePluginsEqual(storedPlugins.value, newPlugins)) return
-      storedPlugins.value = newPlugins
+      if (arePluginsEqual(storedPlugins, newPlugins)) return
+      storedPlugins = newPlugins
       reInit()
     })
   }


### PR DESCRIPTION
Hello, I accidentally came across your module and, after looking at the source code, I really liked it. I would like to thank you for it.

While examining the Vue implementation, I noticed a few areas for improvement. Here is the list:
1. Use `shallowRef` instead of `ref`. It is standard practice to use it for `HTMLElement` and heavy objects that do not require reactivity. We just need to observe the value setting in this case.
2. Use simple variables to store `storedOptions` and `storedPlugins` that do not need reactivity. After all, we only add `watch` for `Ref` objects.
3. The first two improvements also slightly reduce the minified bundle size, as we only call `isRef` once and remove unnecessary accesses to `.value`.