### PR TITLE
fix(react): export EmblaViewportRefType from bundle

### DIFF
--- a/packages/embla-carousel-react/src/components/useEmblaCarousel.ts
+++ b/packages/embla-carousel-react/src/components/useEmblaCarousel.ts
@@ -10,7 +10,7 @@ import EmblaCarousel, {
   EmblaPluginType
 } from 'embla-carousel'
 
-type EmblaViewportRefType = <ViewportElement extends HTMLElement>(
+export type EmblaViewportRefType = <ViewportElement extends HTMLElement>(
   instance: ViewportElement | null
 ) => void
 

--- a/packages/embla-carousel-react/src/index.ts
+++ b/packages/embla-carousel-react/src/index.ts
@@ -1,2 +1,5 @@
-export { UseEmblaCarouselType } from './components/useEmblaCarousel'
+export {
+  UseEmblaCarouselType,
+  EmblaViewportRefType
+} from './components/useEmblaCarousel'
 export { default } from './components/useEmblaCarousel'


### PR DESCRIPTION
Hi David, thanks for your awesome work on Embla!

I recently wrote a small wrapper component around the react plugin and found it would be beneficial to pass around the Embla viewport ref type (for example uses like forwardRef).

This small patch re-exports EmblaViewportRefType from embla-carousel-react. Let me know if there are any questions!