### PR TITLE
[Feat]: Adding updated `onemblaInit` naming for Svelte 5

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/api/events.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/events.mdx
@@ -125,8 +125,12 @@ export function EmblaCarousel() {
   }
 </script>
 
-<div class="embla" use:emblaCarouselSvelte on:emblaInit="{onInit}">...</div>
+<div class="embla" use:emblaCarouselSvelte onemblaInit="{onInit}">...</div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 </TabsItem>
 </Tabs>
@@ -242,8 +246,12 @@ export function EmblaCarousel() {
   }
 </script>
 
-<div class="embla" use:emblaCarouselSvelte on:emblaInit="{onInit}">...</div>
+<div class="embla" use:emblaCarouselSvelte onemblaInit="{onInit}">...</div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 </TabsItem>
 </Tabs>
@@ -400,8 +408,12 @@ export function EmblaCarousel() {
   }
 </script>
 
-<div class="embla" use:emblaCarouselSvelte on:emblaInit="{onInit}">...</div>
+<div class="embla" use:emblaCarouselSvelte onemblaInit="{onInit}">...</div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 <Admonition type="warning">
   If you're using `pnpm`, you need to install `embla-carousel` as a

--- a/packages/embla-carousel-docs/src/content/pages/api/methods.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/methods.mdx
@@ -105,8 +105,12 @@ export function EmblaCarousel() {
   }
 </script>
 
-<div class="embla" use:emblaCarouselSvelte on:emblaInit="{onInit}">...</div>
+<div class="embla" use:emblaCarouselSvelte onemblaInit="{onInit}">...</div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 </TabsItem>
 </Tabs>
@@ -245,8 +249,12 @@ export function EmblaCarousel() {
   }
 </script>
 
-<div class="embla" use:emblaCarouselSvelte on:emblaInit="{onInit}">...</div>
+<div class="embla" use:emblaCarouselSvelte onemblaInit="{onInit}">...</div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 <Admonition type="warning">
   If you're using `pnpm`, you need to install `embla-carousel` as a

--- a/packages/embla-carousel-docs/src/content/pages/api/plugins.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/plugins.mdx
@@ -406,11 +406,15 @@ export function EmblaCarousel() {
 <div
   class="embla"
   use:emblaCarouselSvelte="{{ plugins }}"
-  on:emblaInit="{onInit}"
+  onemblaInit="{onInit}"
 >
   ...
 </div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 </TabsItem>
 </Tabs>
@@ -533,11 +537,15 @@ export function EmblaCarousel() {
 <div
   class="embla"
   use:emblaCarouselSvelte="{{ plugins }}"
-  on:emblaInit="{onInit}"
+  onemblaInit="{onInit}"
 >
   ...
 </div>
 ```
+
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 </TabsItem>
 </Tabs>

--- a/packages/embla-carousel-docs/src/content/pages/get-started/svelte.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/get-started/svelte.mdx
@@ -91,7 +91,7 @@ The `emblaCarouselSvelte` action takes the Embla Carousel [options](/api/options
 <div
   class="embla"
   use:emblaCarouselSvelte="{{ options }}"
-  on:emblaInit="{onInit}"
+  onemblaInit="{onInit}"
 >
   <div class="embla__container">
     <div class="embla__slide">Slide 1</div>
@@ -100,6 +100,9 @@ The `emblaCarouselSvelte` action takes the Embla Carousel [options](/api/options
   </div>
 </div>
 ```
+<Admonition type="note">
+  **Note:** Starting with Svelte 5, the `on:` event handlers have been deprecated. However, `on:emblaInit` will remain for backward compatibility.
+</Admonition>
 
 ## Adding plugins
 

--- a/packages/embla-carousel-svelte/package.json
+++ b/packages/embla-carousel-svelte/package.json
@@ -64,7 +64,7 @@
     "embla-carousel-reactive-utils": "8.2.1"
   },
   "peerDependencies": {
-    "svelte": "^3.49.0 || ^4.0.0"
+    "svelte": "^3.49.0 || ^4.0.0 || ^5.0.0"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/embla-carousel-svelte/src/components/emblaCarouselSvelte.ts
+++ b/packages/embla-carousel-svelte/src/components/emblaCarouselSvelte.ts
@@ -17,6 +17,7 @@ type EmblaCarouselParameterType = {
 
 type EmblaCarouselAttributesType = {
   'on:emblaInit'?: (evt: CustomEvent<EmblaCarouselType>) => void
+  onemblaInit?: (evt: CustomEvent<EmblaCarouselType>) => void
 }
 
 export type EmblaCarouselSvelteType = ActionReturn<


### PR DESCRIPTION
Per the new naming conventions of event handlers: https://svelte-5-preview.vercel.app/docs/event-handlers

This is necessary due to deprecation moving forward and because `Mixing old and new syntaxes for event handling is not allowed. (mixed_event_handler_syntaxes)` https://github.com/sveltejs/svelte/pull/11295

leaving `on:emblaInit` because it will be backward compatible. 

Thanks