### PR TITLE
[react] re-export `EmblaCarouselType`

### DIFF
--- a/packages/embla-carousel-react/src/index.ts
+++ b/packages/embla-carousel-react/src/index.ts
@@ -2,4 +2,7 @@ export {
   UseEmblaCarouselType,
   EmblaViewportRefType
 } from './components/useEmblaCarousel'
+
 export { default } from './components/useEmblaCarousel'
+
+export { EmblaCarouselType } from 'embla-carousel'


### PR DESCRIPTION
Right now if the developer wants to use `EmblaCarouselType` must install `embla-carousel` too. To avoid this I'm just re-exporting it in the barrel file.

### Usage
```diff
-import type { UseEmblaCarouselType } from "embla-carousel-react";
+import type { EmblaCarouselType } from "embla-carousel-react";
-type EmblaCarouselType = NonNullable<UseEmblaCarouselType[1]>;

const options: EmblaCarouselType = {}
```
