### PR TITLE
[Feat]: Add react v19 to peer deps

### DIFF
--- a/packages/embla-carousel-react/package.json
+++ b/packages/embla-carousel-react/package.json
@@ -64,7 +64,7 @@
     "embla-carousel-reactive-utils": "8.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.1 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
   },
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
Thanks a lot for this package

I get the following warning from pnpm after upgrading to NextJS v15 (released today), which installs react 19 RC

React 19 is technically still in RC stage, but since a stable version of a major Metaframework is installing it, it's a sign that it's ready for production use and will now be used by many projects.

```ts
└─┬ embla-carousel-react 8.3.0
  └── ✕ unmet peer react@"^16.8.0 || ^17.0.1 || ^18.0.0": found 19.0.0-rc-65a56d0e-20241020
```
