### PR TITLE
[Feat]: Trigger event (autoplay:select) on autoplay index update

### DIFF
--- a/packages/embla-carousel-autoplay/src/components/Autoplay.ts
+++ b/packages/embla-carousel-autoplay/src/components/Autoplay.ts
@@ -13,6 +13,7 @@ declare module 'embla-carousel' {
   interface EmblaEventListType {
     autoplayPlay: 'autoplay:play'
     autoplayStop: 'autoplay:stop'
+    autoplaySelect: 'autoplay:select'
   }
 }
 
@@ -165,6 +166,8 @@ function Autoplay(userOptions: AutoplayOptionsType = {}): AutoplayType {
     } else {
       emblaApi.scrollTo(0, jump)
     }
+
+    emblaApi.emit('autoplay:select')
   }
 
   const self: AutoplayType = {

--- a/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/plugins/autoplay.mdx
@@ -193,3 +193,11 @@ Once: <BrandPrimaryText>`no`</BrandPrimaryText>
 Fires when autoplay stops playing.
 
 ---
+
+### autoplay:select
+
+Once: <BrandPrimaryText>`no`</BrandPrimaryText>
+
+Fires directly after autoplay selects a new index.
+
+---


### PR DESCRIPTION
Emit autoplay:triggered event on autoplay index change as discussed in:

- https://github.com/davidjerleke/embla-carousel/discussions/1048

Event is emitted after index change; listeners can retrieve the latest selectedScrollSnap from emblaApi regardless of direction to be compatible with upcoming autoplay direction feature.