### PR TITLE
[Bug]: scrollProgress not tightly synced to container translate

### DIFF
--- a/packages/embla-carousel/src/components/EmblaCarousel.ts
+++ b/packages/embla-carousel/src/components/EmblaCarousel.ts
@@ -188,7 +188,7 @@ function EmblaCarousel(
   }
 
   function scrollProgress(): number {
-    return engine.scrollProgress.get(engine.location.get())
+    return engine.scrollProgress.get(engine.offsetLocation.get())
   }
 
   function selectedScrollSnap(): number {

--- a/packages/embla-carousel/src/components/Engine.ts
+++ b/packages/embla-carousel/src/components/Engine.ts
@@ -187,12 +187,9 @@ export function Engine(
     const shouldSettle = scrollBody.settled()
     const withinBounds = !scrollBounds.shouldConstrain()
     const hasSettled = loop ? shouldSettle : shouldSettle && withinBounds
+    const hasSettledAndIdle = hasSettled && !dragHandler.pointerDown()
 
-    if (hasSettled && !dragHandler.pointerDown()) {
-      animation.stop()
-      eventHandler.emit('settle')
-    }
-    if (!hasSettled) eventHandler.emit('scroll')
+    if (hasSettledAndIdle) animation.stop()
 
     const interpolatedLocation =
       location.get() * alpha + previousLocation.get() * (1 - alpha)
@@ -205,6 +202,9 @@ export function Engine(
     }
 
     translate.to(offsetLocation.get())
+
+    if (hasSettledAndIdle) eventHandler.emit('settle')
+    if (!hasSettled) eventHandler.emit('scroll')
   }
 
   const animation = Animations(


### PR DESCRIPTION
- Fixes #1132.

### Changes


- Fix scrollProgress.
- Trigger `scroll` & `settle` events at end of render.