### PR TITLE
[Bug] `emblaApi.plugins()` typed incorrectly / returns undefined when embla carousel is inactive

### DIFF
--- a/packages/embla-carousel/src/components/EmblaCarousel.ts
+++ b/packages/embla-carousel/src/components/EmblaCarousel.ts
@@ -51,7 +51,7 @@ function EmblaCarousel(
   let optionsBase = mergeOptions(defaultOptions, EmblaCarousel.globalOptions)
   let options = mergeOptions(optionsBase)
   let pluginList: EmblaPluginType[] = []
-  let pluginApis: EmblaPluginsType
+  let pluginApis: EmblaPluginsType = {}
 
   let container: HTMLElement
   let slides: HTMLElement[]


### PR DESCRIPTION
- Closes: https://github.com/davidjerleke/embla-carousel/issues/1202.

### Changes

- Initialize pluginApis as an empty object. this properly satisfies its declared type, whereas `undefined` did not.