### PR TITLE
feat: Configurable settle threshold

### DIFF
--- a/packages/embla-carousel-docs/src/content/pages/api/options.mdx
+++ b/packages/embla-carousel-docs/src/content/pages/api/options.mdx
@@ -546,6 +546,15 @@ Enables **infinite looping**. Embla will apply `translateX` or `translateY` to t
 
 ---
 
+### settledThreshold
+
+Type: <BrandPrimaryText>`number`</BrandPrimaryText>
+Default: <BrandSecondaryText>`0.001`</BrandSecondaryText>
+
+Allow the carousel to stop animating when below the threshold.
+
+---
+
 ### skipSnaps
 
 Type: <BrandPrimaryText>`boolean`</BrandPrimaryText>  

--- a/packages/embla-carousel/src/components/Engine.ts
+++ b/packages/embla-carousel/src/components/Engine.ts
@@ -177,7 +177,6 @@ export function Engine(
       previousLocation,
       scrollLooper,
       slideLooper,
-      dragHandler,
       animation,
       eventHandler,
       scrollBounds,

--- a/packages/embla-carousel/src/components/Engine.ts
+++ b/packages/embla-carousel/src/components/Engine.ts
@@ -100,7 +100,8 @@ export function Engine(
     watchResize,
     watchSlides,
     watchDrag,
-    watchFocus
+    watchFocus,
+    settledThreshold
   } = options
 
   // Measurements
@@ -227,7 +228,8 @@ export function Engine(
     previousLocation,
     target,
     duration,
-    friction
+    friction,
+    settledThreshold
   )
   const scrollTarget = ScrollTarget(
     loop,

--- a/packages/embla-carousel/src/components/Options.ts
+++ b/packages/embla-carousel/src/components/Options.ts
@@ -38,6 +38,7 @@ export type OptionsType = CreateOptionsType<{
   watchResize: ResizeHandlerOptionType
   watchSlides: SlidesHandlerOptionType
   watchFocus: FocusHandlerOptionType
+  settledThreshold: number
 }>
 
 export const defaultOptions: OptionsType = {
@@ -60,7 +61,8 @@ export const defaultOptions: OptionsType = {
   watchDrag: true,
   watchResize: true,
   watchSlides: true,
-  watchFocus: true
+  watchFocus: true,
+  settledThreshold: 0.001
 }
 
 export type EmblaOptionsType = Partial<OptionsType>

--- a/packages/embla-carousel/src/components/ScrollBody.ts
+++ b/packages/embla-carousel/src/components/ScrollBody.ts
@@ -26,7 +26,6 @@ export function ScrollBody(
   let scrollDirection = 0
   let scrollDuration = baseDuration
   let scrollFriction = baseFriction
-  let scrollThreshold = settledThreshold
   let rawLocation = location.get()
   let rawLocationPrevious = 0
 
@@ -59,7 +58,7 @@ export function ScrollBody(
 
   function settled(): boolean {
     const diff = target.get() - offsetLocation.get()
-    return mathAbs(diff) < scrollThreshold
+    return mathAbs(diff) < settledThreshold
   }
 
   function duration(): number {

--- a/packages/embla-carousel/src/components/ScrollBody.ts
+++ b/packages/embla-carousel/src/components/ScrollBody.ts
@@ -19,12 +19,14 @@ export function ScrollBody(
   previousLocation: Vector1DType,
   target: Vector1DType,
   baseDuration: number,
-  baseFriction: number
+  baseFriction: number,
+  settledThreshold: number
 ): ScrollBodyType {
   let scrollVelocity = 0
   let scrollDirection = 0
   let scrollDuration = baseDuration
   let scrollFriction = baseFriction
+  let scrollThreshold = settledThreshold
   let rawLocation = location.get()
   let rawLocationPrevious = 0
 
@@ -57,7 +59,7 @@ export function ScrollBody(
 
   function settled(): boolean {
     const diff = target.get() - offsetLocation.get()
-    return mathAbs(diff) < 0.001
+    return mathAbs(diff) < scrollThreshold
   }
 
   function duration(): number {


### PR DESCRIPTION
This PR makes the threshold used to mark the animation as "settled" configurable.

We initially want to influence the threshold because we'd like to mark the first item in a row as focus after settling. We noticed it takes a while for the event to be fired, as the threshold is rather low.

We kept the current value (0.001) as default.