### PR TITLE
[Bug]: Eliminate forced reflow during carousel initialization

### DIFF
--- a/packages/embla-carousel/src/components/EmblaCarousel.ts
+++ b/packages/embla-carousel/src/components/EmblaCarousel.ts
@@ -134,18 +134,20 @@ function EmblaCarousel(
     if (!options.active) return
 
     if (!isSsr && ownerWindow) {
+      engine.resizeHandler.init(ownerWindow)
+      const containerVisible = container.offsetParent
+
       engine.translate.to(engine.location)
       engine.scrollOptimizer.optimize(true)
       if (engine.options.loop) engine.slideLooper.loop()
 
       engine.animation.init(ownerWindow)
-      engine.resizeHandler.init(ownerWindow)
       engine.slidesInView.init(ownerWindow)
       engine.slidesHandler.init(ownerWindow)
       engine.slideFocus.init(ownerWindow)
       engine.eventHandler.init(self)
 
-      if (container.offsetParent && slides.length) {
+      if (containerVisible && slides.length) {
         engine.dragHandler.init(ownerWindow)
       }
     }

--- a/packages/embla-carousel/src/components/NodeHandler.ts
+++ b/packages/embla-carousel/src/components/NodeHandler.ts
@@ -64,12 +64,13 @@ export function NodeHandler(root: HTMLElement): NodeHandlerType {
 
     const containerStyle = root ? container.style : { transform: '' }
     const previousTransform = containerStyle.transform
-    containerStyle.transform = 'none'
+    const needsReset = previousTransform && previousTransform !== 'none'
+    if (needsReset) containerStyle.transform = 'none'
 
     const containerRect = getRect(container)
     const slideRects = slides.map(getRect)
 
-    containerStyle.transform = previousTransform
+    if (needsReset) containerStyle.transform = previousTransform
     rects = { containerRect, slideRects }
     return rects
   }


### PR DESCRIPTION
## Problem

`NodeHandler.getRects()` unconditionally writes `container.style.transform = 'none'` before reading `offsetWidth`/`offsetHeight`, then restores it. This write-then-read pattern forces a synchronous browser reflow on every `activate()` call — even on initial mount when no transform has been applied yet (`transform` is `''`).

Additionally, `activate()` calls `engine.translate.to()` (which writes `style.transform`) before `engine.resizeHandler.init()` (which reads `offsetWidth`/`offsetHeight`), causing a second forced reflow per carousel init.

On pages with multiple carousels, these compound: each carousel init forces 2+ synchronous reflows, blocking the main thread during hydration.

## Fix

**`getRects`**: Guard the transform write — only mutate `style.transform` when it's actually set to something other than `'none'` or `''`. On initial `activate()`, the transform is empty, so the guard skips the write entirely and the `offsetWidth`/`offsetHeight` reads don't force reflow.

**`activate`**: Move `resizeHandler.init()` and `container.offsetParent` (reads) before `translate.to()` and `scrollOptimizer.optimize()` (writes). Neither read depends on the translate position. This batches all layout reads before any layout writes.

## Impact

- Zero behavioral change — same dimensions, same snap points, same drag bounds
- Eliminates forced reflow on initial carousel mount (the hot path)
- On `reActivate()` after scrolling, the transform guard correctly fires when a transform is present

## Verification

Chrome DevTools Performance panel before/after on a page with 9 Embla carousels:
- Before: "Forced reflow while executing JavaScript" per carousel init, ~354ms Style & Layout
- After: Clean — zero forced reflows from Embla, ~150ms Style & Layout