### PR TITLE
[Doc] Update navigation functions to use scroll methods

### DIFF
--- a/website/src/content/v9/code-snippets/get-started/vue/adding-plugins-01.vue
+++ b/website/src/content/v9/code-snippets/get-started/vue/adding-plugins-01.vue
@@ -5,8 +5,8 @@ import Autoplay from 'embla-carousel-autoplay'
 
 const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false }, [Autoplay()])
 
-const goToPrev = () => emblaApi.value?.goToPrev()
-const goToNext = () => emblaApi.value?.goToNext()
+const goToPrev = () => emblaApi.value?.scrollPrev()
+const goToNext = () => emblaApi.value?.scrollNext()
 
 watch(
   emblaApi,


### PR DESCRIPTION
Fixed wrong method used goToPrev -> scrollPrev and goToNext -> scrollNext


