### PR TITLE
[Bug]: Use `MaybeRefOrGetter` instead of `MaybeRef` in `useEmblaCarousel` type def

### DIFF
--- a/packages/embla-carousel-vue/package.json
+++ b/packages/embla-carousel-vue/package.json
@@ -52,14 +52,14 @@
     "rollup": "^4.61.1",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2",
-    "vue": "^3.2.37"
+    "vue": "^3.5.13"
   },
   "dependencies": {
     "embla-carousel": "9.0.0-rc03",
     "embla-carousel-reactive-utils": "9.0.0-rc03"
   },
   "peerDependencies": {
-    "vue": "^3.2.37"
+    "vue": "^3.3.0"
   },
   "exports": {
     "./package.json": "./package.json",

--- a/packages/embla-carousel-vue/src/components/useEmblaCarousel.ts
+++ b/packages/embla-carousel-vue/src/components/useEmblaCarousel.ts
@@ -1,10 +1,18 @@
-import { Ref, MaybeRef, isRef, watch, onBeforeUnmount, shallowRef } from 'vue'
+import {
+  Ref,
+  MaybeRefOrGetter,
+  toValue,
+  watch,
+  onBeforeUnmount,
+  shallowRef
+} from 'vue'
 import { areOptionsEqual, arePluginsEqual } from 'embla-carousel-reactive-utils'
 import EmblaCarousel, {
   EmblaCarouselType,
   EmblaOptionsType,
   EmblaPluginType
 } from 'embla-carousel'
+import { isWatchSource } from './utils'
 
 export type UseEmblaCarouselType = [
   Ref<HTMLElement | undefined>,
@@ -13,16 +21,13 @@ export type UseEmblaCarouselType = [
 ]
 
 function useEmblaCarousel(
-  options: MaybeRef<EmblaOptionsType> = {},
-  plugins: MaybeRef<EmblaPluginType[]> = []
+  options?: MaybeRefOrGetter<EmblaOptionsType | undefined>,
+  plugins?: MaybeRefOrGetter<EmblaPluginType[] | undefined>
 ): UseEmblaCarouselType {
   EmblaCarousel.globalOptions = useEmblaCarousel.globalOptions
 
-  const isRefOptions = isRef(options)
-  const isRefPlugins = isRef(plugins)
-
-  let storedOptions = isRefOptions ? options.value : options
-  let storedPlugins = isRefPlugins ? plugins.value : plugins
+  let storedOptions = toValue(options) ?? {}
+  let storedPlugins = toValue(plugins) ?? []
 
   const serverApi = EmblaCarousel(null, storedOptions, storedPlugins)
   const clientApi = shallowRef<EmblaCarouselType>()
@@ -53,18 +58,20 @@ function useEmblaCarousel(
     if (clientApi.value) clientApi.value.destroy()
   })
 
-  if (isRefOptions) {
+  if (isWatchSource(options)) {
     watch(options, (newOptions) => {
-      if (areOptionsEqual(storedOptions, newOptions)) return
-      storedOptions = newOptions
+      const nextOptions = newOptions ?? {}
+      if (areOptionsEqual(storedOptions, nextOptions)) return
+      storedOptions = nextOptions
       reInit()
     })
   }
 
-  if (isRefPlugins) {
+  if (isWatchSource(plugins)) {
     watch(plugins, (newPlugins) => {
-      if (arePluginsEqual(storedPlugins, newPlugins)) return
-      storedPlugins = newPlugins
+      const nextPlugins = newPlugins ?? []
+      if (arePluginsEqual(storedPlugins, nextPlugins)) return
+      storedPlugins = nextPlugins
       reInit()
     })
   }

--- a/packages/embla-carousel-vue/src/components/utils.ts
+++ b/packages/embla-carousel-vue/src/components/utils.ts
@@ -1,0 +1,7 @@
+import { isReactive, isRef, MaybeRefOrGetter, WatchSource } from 'vue'
+
+export function isWatchSource<T>(
+  value: MaybeRefOrGetter<T>
+): value is WatchSource<T> {
+  return isRef(value) || isReactive(value) || typeof value === 'function'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6782,9 +6782,9 @@ __metadata:
     rollup: ^4.61.1
     ts-jest: ^29.1.1
     typescript: ^5.2.2
-    vue: ^3.2.37
+    vue: ^3.5.13
   peerDependencies:
-    vue: ^3.2.37
+    vue: ^3.3.0
   languageName: unknown
   linkType: soft
 
@@ -16030,7 +16030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.37, vue@npm:^3.5.13":
+"vue@npm:^3.5.13":
   version: 3.5.27
   resolution: "vue@npm:3.5.27"
   dependencies:


### PR DESCRIPTION
- Closes: https://github.com/davidjerleke/embla-carousel/issues/1380

This allows for passing options and plugins to `useEmblaCarousel` as either computed properties or getters.

Bumps vue peer dep to 3.3.0 to ensure these utils are available.

(We could also extend it so that `MaybeRefOrGetter` can hold `undefined` too!)