### PR TITLE
[Bug]: reInit() is called synchronously inside ResizeObserver callback

### DIFF
--- a/packages/embla-carousel/src/__tests__/resize-ltr.test.ts
+++ b/packages/embla-carousel/src/__tests__/resize-ltr.test.ts
@@ -155,4 +155,83 @@ describe('➡️  Resize - Horizontal LTR', () => {
       expect(callback).toHaveBeenCalledTimes(0)
     })
   })
+
+  describe('When multiple resize batches arrive before the deferred reinitialize runs', () => {
+    // window.requestAnimationFrame is already a jest.fn() (see
+    // mocks/requestAnimationFrame.mock.ts) that invokes its callback
+    // synchronously. mockImplementationOnce overrides it for exactly the one
+    // call under test and then automatically falls back to that default
+    // synchronous behavior, so nothing needs to be restored afterwards - and
+    // unrelated requestAnimationFrame calls elsewhere in the engine are
+    // unaffected.
+    function captureNextAnimationFrame(): { frame?: FrameRequestCallback } {
+      const captured: { frame?: FrameRequestCallback } = {}
+      ;(window.requestAnimationFrame as jest.Mock).mockImplementationOnce(
+        (callback: FrameRequestCallback) => {
+          captured.frame = callback
+          return 1
+        }
+      )
+      return captured
+    }
+
+    test('The carousel only reinitializes once, deferred to an animation frame', () => {
+      const emblaApi = EmblaCarousel(mockTestElements(FIXTURE_RESIZE_LTR), {
+        resize: true
+      })
+
+      const firstSlide = emblaApi.slideNodes()[0]
+      const firstSlideWidth = emblaApi.internalEngine().slideRects[0].width
+      const reInit = jest.spyOn(emblaApi, 'reInit')
+      const captured = captureNextAnimationFrame()
+
+      Object.defineProperty(firstSlide, 'offsetWidth', {
+        value: firstSlideWidth + RESIZE_TRIGGER_THRESHOLD,
+        configurable: true
+      })
+      triggerResizeObserver([{ target: firstSlide }])
+      triggerResizeObserver([{ target: firstSlide }])
+      triggerResizeObserver([{ target: firstSlide }])
+
+      // reInit() must not run synchronously from inside the ResizeObserver
+      // callback, and the three batches above must schedule only one frame
+      // (the mocked call above was only consumed once).
+      expect(reInit).toHaveBeenCalledTimes(0)
+
+      captured.frame?.(1)
+
+      // The three batches above must still only reinitialize once.
+      expect(reInit).toHaveBeenCalledTimes(1)
+    })
+
+    test('A pending reinitialize is cancelled if the carousel is destroyed first', () => {
+      const emblaApi = EmblaCarousel(mockTestElements(FIXTURE_RESIZE_LTR), {
+        resize: true
+      })
+
+      const firstSlide = emblaApi.slideNodes()[0]
+      const firstSlideWidth = emblaApi.internalEngine().slideRects[0].width
+      const reInit = jest.spyOn(emblaApi, 'reInit')
+      const captured = captureNextAnimationFrame()
+      const cancelSpy = jest.spyOn(window, 'cancelAnimationFrame')
+
+      Object.defineProperty(firstSlide, 'offsetWidth', {
+        value: firstSlideWidth + RESIZE_TRIGGER_THRESHOLD,
+        configurable: true
+      })
+      triggerResizeObserver([{ target: firstSlide }])
+
+      expect(cancelSpy).toHaveBeenCalledTimes(0)
+
+      emblaApi.destroy()
+
+      expect(cancelSpy).toHaveBeenCalledTimes(1)
+
+      // Even if the frame still fires after destroy, reInit() must not run.
+      captured.frame?.(1)
+      expect(reInit).toHaveBeenCalledTimes(0)
+
+      cancelSpy.mockRestore()
+    })
+  })
 })

--- a/packages/embla-carousel/src/components/ResizeHandler.ts
+++ b/packages/embla-carousel/src/components/ResizeHandler.ts
@@ -1,4 +1,5 @@
 import { AxisType } from './Axis'
+import { EmblaCarouselType } from './EmblaCarousel'
 import { EventHandlerType } from './EventHandler'
 import { NodeHandlerType } from './NodeHandler'
 import { mathAbs, WindowType } from './utils'
@@ -21,6 +22,9 @@ export function ResizeHandler(
   let containerSize: number
   let slideSizes: number[] = []
   let destroyed = false
+  let resizeWindow: WindowType
+  let reInitAnimationFrame: number | null = null
+  let reInitScheduled = false
 
   function readSize(node: HTMLElement): number {
     return axis.getSize(nodeHandler.getRect(node))
@@ -29,6 +33,7 @@ export function ResizeHandler(
   function init(ownerWindow: WindowType): void {
     if (!active) return
 
+    resizeWindow = ownerWindow
     containerSize = readSize(container)
     slideSizes = slides.map(readSize)
 
@@ -41,6 +46,26 @@ export function ResizeHandler(
   function destroy(): void {
     destroyed = true
     if (resizeObserver) resizeObserver.disconnect()
+    if (reInitAnimationFrame !== null) {
+      resizeWindow.cancelAnimationFrame(reInitAnimationFrame)
+      reInitAnimationFrame = null
+    }
+    reInitScheduled = false
+  }
+
+  function scheduleReInit(api: EmblaCarouselType): void {
+    // Defer reInit() instead of calling it synchronously from inside the
+    // ResizeObserver callback, which browsers can report as a ResizeObserver
+    // loop. Multiple resize batches arriving before the frame fires collapse
+    // into a single reInit() call.
+    if (reInitScheduled) return
+    reInitScheduled = true
+
+    reInitAnimationFrame = resizeWindow.requestAnimationFrame(() => {
+      reInitScheduled = false
+      reInitAnimationFrame = null
+      if (!destroyed) api.reInit()
+    })
   }
 
   function onResize(entries: ResizeObserverEntry[]): void {
@@ -59,7 +84,7 @@ export function ResizeHandler(
       const diffSize = mathAbs(newSize - lastSize)
 
       if (diffSize >= 0.5) {
-        event.api.reInit()
+        scheduleReInit(event.api)
         break
       }
     }


### PR DESCRIPTION
## Summary

- Fixes #1321.

`ResizeHandler`'s `onResize` calls `event.api.reInit()` synchronously from inside the `ResizeObserver` callback whenever a watched node's size changes by 0.5px or more:

```ts
if (diffSize >= 0.5) {
  event.api.reInit()
  break
}
```

`reInit()` can itself change layout (slide translation, etc.), which the observer picks up while still delivering the current notification batch — some browsers report this pattern as a `ResizeObserver loop` warning. This reproduces deterministically in an isolated, framework-free repro (see the issue) by tracking whether `reInit()` runs while the `ResizeObserver` callback is still active.

## Fix

Defer `reInit()` to a `requestAnimationFrame` instead of calling it synchronously, matching the same approach already used for the initial `observe()` calls in this file. To address the point raised in the issue thread about not just trading the warning for avoidable work, this also:

- **Coalesces** multiple resize batches: if further batches arrive before the pending frame fires, they don't schedule additional `reInit()` calls — a burst of `ResizeObserver` notifications settles into a single reinitialize.
- **Cancels** the pending frame on `destroy()`, so a resize that fires just before teardown can't call `reInit()` against an already-destroyed instance.

## Test plan

- Added two tests to `resize-ltr.test.ts`:
  - Three resize batches in a row schedule only one deferred `reInit()`, and it doesn't run until the frame fires.
  - A pending reinitialize is cancelled (via `cancelAnimationFrame`) when the carousel is destroyed first, and `reInit()` is not called even if the frame still fires afterward.
- Verified the regression: reverting the source change turns both new tests from passing into failing — `reInit()` runs synchronously instead of being deferred, and `cancelAnimationFrame` is never called on destroy.
- Full package suite passes: `yarn jest --config jest.config.js` — 572 passing, all 3 resize test files (ltr/rtl/vertical, 23 tests) included, no changes needed to the existing tests.
- `eslint`, `tsc --noEmit`, and `prettier --check` all pass on the changed files.